### PR TITLE
Adding caliper-event-annotation; modifying caliper-event-feedback

### DIFF
--- a/fragments/events/caliper-event-annotation.html
+++ b/fragments/events/caliper-event-annotation.html
@@ -2,8 +2,8 @@
 
 <img height="100%" width="100%" src="assets/caliper-annotation_event_highlighted-v2.png" alt="AnnotationEvent Highlighted image"/>
 
-<p>A Caliper <a href="#annotationEvent">AnnotationEvent</a> models the annotating of digital content. The resulting <a
-        href="#annotation">Annotation</a> is also described and is subtyped for greater type specificity.</p>
+<p>A Caliper <code>AnnotationEvent</code> models the annotating of digital content. The resulting <a
+        href="#Annotation">Annotation</a> is also described and is subtyped for greater type specificity.</p>
 
 <dl>
     <dt>IRI</dt>
@@ -74,7 +74,7 @@
     <tr>
         <td>generated</td>
         <td><a href="#Annotation">Annotation</a> | <a href="#iriDef">IRI</a></td>
-        <td>The <code>generated</code> <a href="#annotation">Annotation</a> or a subtype. The <code>generated</code>
+        <td>The <code>generated</code> <a href="#Annotation">Annotation</a> or a subtype. The <code>generated</code>
             value MUST be expressed either as an object or as a string corresponding to the generated entity's
             <a href="#iriDef">IRI</a>.
         </td>

--- a/fragments/events/caliper-event-annotation.html
+++ b/fragments/events/caliper-event-annotation.html
@@ -1,0 +1,84 @@
+<h3>AnnotationEvent</h3>
+
+<img height="100%" width="100%" src="assets/caliper-annotation_event_highlighted-v2.png" alt="AnnotationEvent Highlighted image"/>
+
+<p>A Caliper <a href="#annotationEvent">AnnotationEvent</a> models the annotating of digital content. The resulting <a
+        href="#annotation">Annotation</a> is also described and is subtyped for greater type specificity.</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd><a href="http://purl.imsglobal.org/caliper/AnnotationEvent">http://purl.imsglobal.org/caliper/AnnotationEvent</a></dd>
+    <dt>Term</dt>
+    <dd>AnnotationEvent</dd>
+    <dt>Supertype</dt>
+    <dd><a href="#Event">Event</a></dd>
+    <dt>Properties</dt>
+    <dd>The <code>AnnotationEvent</code> inherits all properties defined by its supertype <a href="#Event">Event</a>,
+        of which <code>id</code>, <code>type</code>, <code>actor</code>, <code>action</code>,
+        <code>object</code>, and <code>eventTime</code> are required. Additional profile-specific type and value
+        restrictions are described below:
+    </dd>
+</dl>
+
+<table class="data">
+    <thead>
+    <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Disposition</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>type</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The string value MUST be set to the <a href="#termDef">Term</a> <em>AnnotationEvent</em>.</td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>actor</td>
+        <td><a href="#Person">Person</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#Person">Person</a> who initiated the <code>action</code>. The <code>actor</code> value MUST be
+            expressed either as an object or as a string corresponding to the actor's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>action</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The action or predicate that binds the <code>actor</code> or subject to the <code>object</code>. The value
+            range is limited to the <a href="#bookmarked">Bookmarked</a>, <a href="#highlighted">Highlighted</a>,
+            <a href="#shared">Shared</a>, and <a href="#tagged">Tagged</a> actions only.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>object</td>
+        <td><a href="#DigitalResource">DigitalResource</a> | <a href="#iriDef">IRI</a></td>
+        <td>The annotated <a href="#DigitalResource">DigitalResource</a> that constitutes the <code>object</code> of the
+            interaction. The <code>object</code> value MUST be expressed either as an object or as a string
+            corresponding to the object's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>target</td>
+        <td><a href="#Frame">Frame</a> | <a href="#iriDef">IRI</a></td>
+        <td>A <a href="#Frame">Frame</a> that represents a particular segment or location within the <code>object</code>.
+            The <code>target</code> value MUST be expressed either as an object or as a string corresponding to the
+            target entity's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Optional</td>
+    </tr>
+    <tr>
+        <td>generated</td>
+        <td><a href="#Annotation">Annotation</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <code>generated</code> <a href="#annotation">Annotation</a> or a subtype. The <code>generated</code>
+            value MUST be expressed either as an object or as a string corresponding to the generated entity's
+            <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Optional</td>
+    </tr>
+    </tbody>
+</table>

--- a/fragments/events/caliper-event-feedback.html
+++ b/fragments/events/caliper-event-feedback.html
@@ -39,7 +39,7 @@
         <td><a href=
            "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#termDef"
         >Term</a></td>
-        <td>The string value MUST be set to <em>FeedbackEvent</em>.</td>
+        <td>The string value MUST be set to the <a href="#termDef">Term</a> <em>FeedbackEvent</em>.</td>
         <td>Required</td>
     </tr>
     <tr>
@@ -49,8 +49,8 @@
         >Person</a> | <a href=
              "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
         >IRI</a></td>
-        <td>The <code>Person</code> who initiated the action. The <code>actor</code> value MUST
-            be expressed either as an object or as a string corresponding to the actor's IRI.
+        <td>The <code>Person</code> who initiated the action. The <code>actor</code> value MUST be expressed either as
+            an object or as a string corresponding to the actor's IRI.
         </td>
         <td>Required</td>
     </tr>


### PR DESCRIPTION
This PR includes a new caliper-event-annotation.html doc in the fragments/events directory. It also includes some small tweaks to caliper-event-feedback.html in the same directory to increase consistency.