### PR TITLE
Two new event docs; sections with data-include added to respec doc

### DIFF
--- a/caliper-spec-respec.html
+++ b/caliper-spec-respec.html
@@ -377,7 +377,10 @@
 
     <section id="events">
         <h2>Event subtypes</h2>
+        <section id="AnnotationEvent" data-include="fragments/events/caliper-event-annotation.html"></section>
         <section id="AssessmentEvent" data-include="fragments/events/caliper-event-assessment.html"></section>
+        <section id="AssessmentItemEvent" data-include="fragments/events/caliper-event-assessmentitem.html"></section>
+        <section id="AssignableEvent" data-include="fragments/events/caliper-event-assignable.html"></section>
         <section id="FeedbackEvent" data-include="fragments/events/caliper-event-feedback.html"></section>
         <section id="NavigationEvent" data-include="fragments/events/caliper-event-navigation.html"></section>
         <section id="QuestionnaireEvent" data-include="fragments/events/caliper-event-questionnaire.html"></section>

--- a/caliper-spec-respec.html
+++ b/caliper-spec-respec.html
@@ -382,6 +382,7 @@
         <section id="AssessmentItemEvent" data-include="fragments/events/caliper-event-assessmentitem.html"></section>
         <section id="AssignableEvent" data-include="fragments/events/caliper-event-assignable.html"></section>
         <section id="FeedbackEvent" data-include="fragments/events/caliper-event-feedback.html"></section>
+        <section id="ForumEvent" data-include="fragments/events/caliper-event-forum.html"></section>
         <section id="NavigationEvent" data-include="fragments/events/caliper-event-navigation.html"></section>
         <section id="QuestionnaireEvent" data-include="fragments/events/caliper-event-questionnaire.html"></section>
         <section id="QuestionnaireItemEvent" data-include="fragments/events/caliper-event-questionnaireitem.html"></section>

--- a/fragments/events/caliper-event-assignable.html
+++ b/fragments/events/caliper-event-assignable.html
@@ -1,0 +1,84 @@
+<h3>AssignableEvent</h3>
+
+<img height="100%" width="100%" src="assets/caliper-assignable_event_activated-v2.png"
+     alt="AssignableEvent Activated image">
+
+<p>A Caliper <code>AssignableEvent</code> models activities associated with the assignment of digital content assigned
+    to a learner for completion.</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd><a href="http://purl.imsglobal.org/caliper/AssignableEvent">http://purl.imsglobal.org/caliper/AssignableEvent</a></dd>
+    <dt>Term</dt>
+    <dd>AssignableEvent</dd>
+    <dt>Supertype</dt>
+    <dd><a href="#Event">Event</a></dd>
+    <dt>Properties</dt>
+    <dd>The <code>AssignableEvent</code> inherits all properties defined by its supertype <a href="#Event">Event</a>,
+        of which <code>id</code>, <code>type</code>, <code>actor</code>, <code>action</code>,
+        <code>object</code>, and <code>eventTime</code> are required. Additional profile-specific type and value
+        restrictions are described below:
+    </dd>
+</dl>
+
+<table class="data">
+    <thead>
+    <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Disposition</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>type</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The string value MUST be set to the <a href="#termDef">Term</a> <em>AssignableEvent</em>.</td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>actor</td>
+        <td><a href="#Person">Person</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#Person">Person</a> who initiated the <code>action</code>. The <code>actor</code> value MUST be
+            expressed either as an object or as a string corresponding to the actor's <a href="#iriDef">IRI</a>.</td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>action</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The action or predicate that binds the <code>actor</code> or subject to the <code>object</code>. The value
+            range is limited to the <a href="#action-activated">Activated</a>,
+            <a href="#action-deactivated">Deactivated</a>, <a href="#action-started">Started</a>,
+            <a href="#action-completed">Completed</a>, <a href="#action-submitted">Submitted</a>, and
+            <a href="#action-reviewed">Reviewed</a> actions only.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>object</td>
+        <td><a href="#AssignableDigitalResource">AssignableDigitalResource</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#AssignableDigitalResource">AssignableDigitalResource</a> that constitutes the
+            <code>object</code> of the interaction. The <code>object</code> value MUST be expressed either as an object
+            or as a string corresponding to the object's <a href="#iriDef">IRI</a>.</td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>target</td>
+        <td><a href="#Frame">Frame</a> | <a href="#iriDef">IRI</a></td>
+        <td>A <a href="#Frame">Frame</a> that represents a particular segment or location within the <code>object</code>.
+            The <code>target</code> value MUST be expressed either as an object or as a string corresponding to the
+            target entity's <a href="#iriDef">IRI</a>.</td>
+        <td>Optional</td>
+    </tr>
+    <tr>
+        <td>generated</td>
+        <td><a href="#Attempt">Attempt</a> | <a href="#iriDef">IRI</a></td>
+        <td>For <a href="#action-started">Started</a>, <a href="#action-completed">Completed</a> and
+            <a href="#action-reviewed">Reviewed</a> actions, the actor's <a href="#Attempt">Attempt</a> SHOULD be
+            specified. The <code>generated</code> value MUST be expressed either as an object or as a string
+            corresponding to the generated entity's <a href="#iriDef">IRI</a>.</td>
+        <td>Optional</td>
+    </tr>
+    </tbody>
+</table>

--- a/fragments/events/caliper-event-forum.html
+++ b/fragments/events/caliper-event-forum.html
@@ -1,0 +1,67 @@
+<h3>ForumEvent</h3>
+
+<img height="100%" width="100%" src="assets/caliper-forum_event_subscribed-v2.png" alt="ForumEvent Subscribed image">
+
+<p>A Caliper <code>ForumEvent</code> models learners and others participating in online forum communities. Forums
+    typically encompass one or more threads or topics to which members can subscribe, post messages, and reply to
+    other messages if a threaded discussion is permitted.</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd><a href="http://purl.imsglobal.org/caliper/ForumEvent">http://purl.imsglobal.org/caliper/ForumEvent</a></dd>
+    <dt>Term</dt>
+    <dd>ForumEvent</dd>
+    <dt>Supertype</dt>
+    <dd><a href="#Event">Event</a></dd>
+    <dt>Properties</dt>
+    <dd>The <code>ForumEvent</code> inherits all properties defined by its supertype <a href="#Event">Event</a>,
+        of which <code>id</code>, <code>type</code>, <code>actor</code>, <code>action</code>,
+        <code>object</code>, and <code>eventTime</code> are required. Additional profile-specific type and value
+        restrictions are described below:
+    </dd>
+</dl>
+
+<table>
+    <thead>
+    <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Disposition</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>type</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The string value MUST be set to the <a href="#termDef">Term</a> <em>ForumEvent</em>.</td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>actor</td>
+        <td><a href="#Person">Person</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#Person">Person</a> who initiated the <code>action</code>. The <code>actor</code> value MUST be
+            expressed either as an object or as a string corresponding to the actor's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>action</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The action or predicate that binds the <code>actor</code> or subject to the <code>object</code>. The value
+            range is limited to the <a href="#action-subscribed">Subscribed</a> and
+            <a href="#action-unsubscribed">Unsubscribed</a> actions only.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>object</td>
+        <td><a href="#Forum">Forum</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#Forum">Forum</a> that comprises the <code>object</code> of this interaction. The
+            <code>object</code> value MUST be expressed either as an object or as a string corresponding to the
+            object's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    </tbody>
+</table>


### PR DESCRIPTION
This PR includes two new HTML event fragments, caliper-event-assignable.html and caliper-event-forum.html, as well as new sections with data-include attributes under Event subtypes.