### PR TITLE
Adding rest of the event docs; fixing formatting

### DIFF
--- a/caliper-spec-respec.html
+++ b/caliper-spec-respec.html
@@ -383,13 +383,18 @@
         <section id="AssignableEvent" data-include="fragments/events/caliper-event-assignable.html"></section>
         <section id="FeedbackEvent" data-include="fragments/events/caliper-event-feedback.html"></section>
         <section id="ForumEvent" data-include="fragments/events/caliper-event-forum.html"></section>
+        <section id="GradeEvent" data-include="fragments/events/caliper-event-grade.html"></section>
+        <section id="MediaEvent" data-include="fragments/events/caliper-event-media.html"></section>
+        <section id="MessageEvent" data-include="fragments/events/caliper-event-message.html"></section>
         <section id="NavigationEvent" data-include="fragments/events/caliper-event-navigation.html"></section>
         <section id="QuestionnaireEvent" data-include="fragments/events/caliper-event-questionnaire.html"></section>
         <section id="QuestionnaireItemEvent" data-include="fragments/events/caliper-event-questionnaireitem.html"></section>
         <section id="ResourceManagementEvent" data-include="fragments/events/caliper-event-resourcemanagement.html"></section>
         <section id="SearchEvent" data-include="fragments/events/caliper-event-search.html"></section>
+        <section id="SessionEvent" data-include="fragments/events/caliper-event-session.html"></section>
         <section id="SurveyEvent" data-include="fragments/events/caliper-event-survey.html"></section>
         <section id="SurveyInvitationEvent" data-include="fragments/events/caliper-event-surveyinvitation.html"></section>
+        <section id="ThreadEvent" data-include="fragments/events/caliper-event-thread.html"></section>
         <section id="ToolLaunchEvent" data-include="fragments/events/caliper-event-toollaunch.html"></section>
         <section id="ToolUseEvent" data-include="fragments/events/caliper-event-tooluse.html"></section>
         <section id="ViewEvent" data-include="fragments/events/caliper-event-view.html"></section>

--- a/fragments/events/caliper-event-annotation.html
+++ b/fragments/events/caliper-event-annotation.html
@@ -1,9 +1,11 @@
 <h3>AnnotationEvent</h3>
 
-<img height="100%" width="100%" src="assets/caliper-annotation_event_highlighted-v2.png" alt="AnnotationEvent Highlighted image">
+<img height="100%" width="100%" src="assets/caliper-annotation_event_highlighted-v2.png"
+     alt="AnnotationEvent Highlighted image">
 
-<p>A Caliper <code>AnnotationEvent</code> models the annotating of digital content. The resulting <a
-        href="#Annotation">Annotation</a> is also described and is subtyped for greater type specificity.</p>
+<p>A Caliper <code>AnnotationEvent</code> models the annotating of digital content. The resulting
+    <a href="#Annotation">Annotation</a> is also described and is subtyped for greater type specificity.
+</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/events/caliper-event-assessment.html
+++ b/fragments/events/caliper-event-assessment.html
@@ -38,7 +38,7 @@
     <tr>
         <td>actor</td>
         <td><a href="#Person">Person</a> | <a href="#iriDef">IRI</a></td>
-        <td>the <a href="#Person">Person</a> who initiated the <code>action</code>. The <code>actor</code> value MUST be
+        <td>The <a href="#Person">Person</a> who initiated the <code>action</code>. The <code>actor</code> value MUST be
             expressed either as an object or as a string corresponding to the actor's <a href="#iriDef">IRI</a>.
         </td>
         <td>Required</td>

--- a/fragments/events/caliper-event-event.html
+++ b/fragments/events/caliper-event-event.html
@@ -2,33 +2,33 @@
 
 <img height="100%" width="100%" src="assets/caliper-event_model_no_title-v3.png" alt="Caliper Event">
 
-<p>A Caliper <a href="#Event">Event</a> is a generic type that describes the relationship established between an
+<p>A Caliper <code>Event</code> is a generic type that describes the relationship established between an
     <code>action</code> and an <code>object</code>, formed as a result of a purposeful
     <a href="#actions">action</a> undertaken by the <code>action</code> at a particular moment in time and within a
-    given learning context. The <a href="#Event">Event</a> properties <code>action</code>, <code>action</code> and
+    given learning context. The <code>Event</code> properties <code>action</code>, <code>action</code> and
     <code>object</code> form a compact data structure that resembles an <a href="#rdf">RDF</a> triple linking a subject
     to an object via a predicate. A learner starting an assessment, annotating a reading, pausing a video, or
     posting a message to a forum, are examples of learning activities that Caliper models as events.</p>
 
-<p>Caliper defines a number of <a href="#Event">Event</a> subtypes, each scoped to a particular activity domain and
+<p>Caliper defines a number of <code>Event</code> subtypes, each scoped to a particular activity domain and
     distinguishable by a <code>type</code> attribute. The <code>type</code> value is a string that MUST match the
-    <a href="#termDef">Term</a> specified for the <a href="#Event">Event</a> by the Caliper information model
-    (e.g. "MessageEvent"). Each <a href="#Event">Event</a> instance is assigned a 128-bit long universally unique
+    <a href="#termDef">Term</a> specified for the <code>Event</code> by the Caliper information model
+    (e.g. "MessageEvent"). Each <code>Event</code> instance is assigned a 128-bit long universally unique
     identifier (UUID) formatted as a <a href="#urnDef">URN</a> per <a href="#rfc4122">RFC 4122</a>, which describes
     a <a href="#urnDef">URN</a> namespace for <a href="#uuidDef">UUIDs</a>.</p>
 
 <p>The information model also seeks to describe the learning environment or context in which a learning
     activity is situated. Group affiliation, membership roles and status, recent navigation history,
-    supporting technology and session information can all be optionally represented. An <a href="#entity">Entity</a>
+    supporting technology and session information can all be optionally represented. An <a href="#Entity">Entity</a>
     generated as a result of the interaction between an <code>action</code> and an <code>object</code> can also be described;
     annotating a piece of digital content and producing an <a href="#Annotation">Annotation</a> is one such example.
     An <code>extensions</code> property is also provided so that implementers can add custom attributes not described
     by the model.</p>
 
-<p>Considered as a data structure an <a href="#Event">Event</a> constitutes an unordered set of key:value pairs that is
-    semi-structured by design. Optional attributes can be ignored when describing an <a href="#Event">Event</a>. An
-    <a href="#entity">Entity</a> participating in an <a href="#Event">Event</a> can be represented as an object or as a
-    string that corresponds to the <a href="#iriDef">IRI</a> defined for the <a href="#entity">Entity</a>.</p>
+<p>Considered as a data structure an <code>Event</code> constitutes an unordered set of key:value pairs that is
+    semi-structured by design. Optional attributes can be ignored when describing an <code>Event</code>. An
+    <a href="#Entity">Entity</a> participating in an <code>Event</code> can be represented as an object or as a
+    string that corresponds to the <a href="#iriDef">IRI</a> defined for the <a href="#Entity">Entity</a>.</p>
 
 <dl>
     <dt>IRI</dt>
@@ -60,7 +60,7 @@
         <a href="#ViewEvent">ViewEvent</a>
     </dd>
     <dt>Properties</dt>
-    <dd>The base set of <a href="#Event">Event</a> properties or attributes is listed below. Each property MUST be
+    <dd>The base set of <code>Event</code> properties or attributes is listed below. Each property MUST be
         referenced only once. The <code>id</code>, <code>type</code>, <code>action</code>, <code>action</code>,
         <code>object</code> and <code>eventTime</code> properties are required; all other properties are optional.
         Custom attributes not described by the model MAY be included but MUST be added to the <code>extensions</code>
@@ -82,7 +82,7 @@
     <tr>
         <td>id</td>
         <td><a href="#uuidDef">UUID</a></td>
-        <td>The emitting application MUST provision the <a href="#Event">Event</a> with a <a href="#uuidDef">UUID</a>.
+        <td>The emitting application MUST provision the <code>Event</code> with a <a href="#uuidDef">UUID</a>.
             A version 4 <a href="#uuidDef">UUID</a> SHOULD be generated. The UUID MUST be expressed as a
             <a href="#urnDef">URN</a> using the form <code>urn:uuid:&lt;UUID&gt;</code> per
             <a href="#rfc4122">RFC 4122</a>.</td>
@@ -91,10 +91,10 @@
     <tr>
         <td>type</td>
         <td><a href="#termDef">Term</a></td>
-        <td>A string value corresponding to the <a href="#termDef">Term</a> defined for the <a href="#Event">Event</a>
+        <td>A string value corresponding to the <a href="#termDef">Term</a> defined for the <code>Event</code>
             in the external IMS Caliper JSON-LD <a href="http://purl.imsglobal.org/ctx/caliper/v1p2">context</a>document.
-            For a generic <a href="#Event">Event</a> set the <code>type</code> to the string value <em>Event</em>.
-            If a subtype of <a href="#entity">Entity</a> is created, set the <code>type</code> to the
+            For a generic <code>Event</code> set the <code>type</code> to the string value <em>Event</em>.
+            If a subtype of <a href="#Entity">Entity</a> is created, set the <code>type</code> to the
             <a href="#termDef">Term</a> corresponding to the subtype utilized, e.g., <em>NavigationEvent</em>.</td>
         <td>Required</td>
     </tr>
@@ -103,16 +103,16 @@
         <td><a href="#termDef">Term</a></td>
         <td>A string value corresponding to the <a href="#termDef">Term</a> defined for the
             <a href="#profileDef">Profile</a> that governs the vocabulary used in the creation of the
-            <a href="#event">Event</a>. The list of <a href="#profileDef">Profile</a> terms is listed in the external
+            <code>Event</code>. The list of <a href="#profileDef">Profile</a> terms is listed in the external
             IMS Caliper JSON-LD <a href="http://purl.imsglobal.org/ctx/caliper/v1p2">context</a>document. For a generic
-            <a href="#Event">Event</a> set the <code>profile</code> property value to the string term
+            <code>Event</code> set the <code>profile</code> property value to the string term
             *GeneralProfile*.</td>
         <td>Required</td>
     </tr>
     <tr>
         <td>actor</td>
         <td><a href="#Agent">Agent</a> | <a href="#iriDef">IRI</a></td>
-        <td>The <a href="#Agent">Agent</a> who initiated the <a href="#Event">Event</a>, typically though not always a
+        <td>The <a href="#Agent">Agent</a> who initiated the <code>Event</code>, typically though not always a
             <a href="#Person">Person</a>. The <code>action</code> value MUST be expressed either as an object or as a
             string corresponding to the actor's <a href="#iriDef">IRI</a>.</td>
         <td>Required</td>
@@ -122,14 +122,14 @@
         <td><a href="#termDef">Term</a></td>
         <td>The action or predicate that binds the actor or subject to the object. The <code>action</code> range is
             limited to the set of <a href="#actions">actions</a> described in this specification or associated profiles
-            and may be further constrained by the chosen <a href="#Event">Event</a> type. Only one <code>action</code>
-            <a href="#termDef">Term</a> may be specified per <a href="#Event">Event</a>.</td>
+            and may be further constrained by the chosen <code>Event</code> type. Only one <code>action</code>
+            <a href="#termDef">Term</a> may be specified per <code>Event</code>.</td>
         <td>Required</td>
     </tr>
     <tr>
         <td>object</td>
-        <td><a href="#entity">Entity</a> | <a href="#iriDef">IRI</a></td>
-        <td>The <a href="#entity">Entity</a> that comprises the object of the interaction. The <code>object</code> value
+        <td><a href="#Entity">Entity</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#Entity">Entity</a> that comprises the object of the interaction. The <code>object</code> value
             MUST be expressed either as an object or as a string corresponding to the object's
             <a href="#iriDef">IRI</a>.</td>
         <td>Required</td>
@@ -138,14 +138,14 @@
         <td>eventTime</td>
         <td>DateTime</td>
         <td>An ISO 8601 date and time value expressed with millisecond precision that indicates when the
-            <a href="#Event">Event</a> occurred. The value MUST be expressed using the format YYYY-MM-DDTHH:mm:ss.SSSZ
+            <code>Event</code> occurred. The value MUST be expressed using the format YYYY-MM-DDTHH:mm:ss.SSSZ
             set to UTC with no offset specified.</td>
         <td>Required</td>
     </tr>
     <tr>
         <td>target</td>
         <td><a href="#Entity">Entity</a> | <a href="#iriDef">IRI</a></td>
-        <td>An <a href="#entity">Entity</a> that represents a particular segment or location within the
+        <td>An <a href="#Entity">Entity</a> that represents a particular segment or location within the
             <code>object</code>. The <code>target</code> value MUST be expressed either as an object or as a string
             corresponding to the target entity's <a href="#iriDef">IRI</a>.</td>
         <td>Optional</td>
@@ -153,7 +153,7 @@
     <tr>
         <td>generated</td>
         <td><a href="#Entity">Entity</a> | <a href="#iriDef">IRI</a></td>
-        <td>An <a href="#entity">Entity</a> created or generated as a result of the interaction. The
+        <td>An <a href="#Entity">Entity</a> created or generated as a result of the interaction. The
             <code>generated</code> value MUST be expressed either as an object or as a string corresponding to the
             generated entity's <a href="#iriDef">IRI</a>.</td>
         <td>Optional</td>
@@ -178,7 +178,7 @@
     <tr>
         <td>group</td>
         <td><a href="#Organization">Organization</a> | <a href="#iriDef">IRI</a></td>
-        <td>An <a href="#organization">Organization</a> that represents the group context. The <code>group</code> value
+        <td>An <a href="#Organization">Organization</a> that represents the group context. The <code>group</code> value
             MUST be expressed either as an object or as a string corresponding to the group's
             <a href="#iriDef">IRI</a>.</td>
         <td>Optional</td>
@@ -201,7 +201,7 @@
     <tr>
         <td>federatedSession</td>
         <td><a href="#FederatedSession">federatedSession</a> | <a href="#iriDef">IRI</a></td>
-        <td>If the <a href="#Event">Event</a> occurs within the context of an <a href="#ltiDef">LTI</a> platform launch,
+        <td>If the <code>Event</code> occurs within the context of an <a href="#ltiDef">LTI</a> platform launch,
             the tool's <a href="#LtiSession">LtiSession</a> MAY be referenced. The <code>federatedSession</code>
             value MUST be expressed either as an object or as a string corresponding to the federated session's
             <a href="#iriDef">IRI</a>.</td>
@@ -211,7 +211,7 @@
         <td>extensions</td>
         <td>Object</td>
         <td>A map of additional attributes not defined by the model MAY be specified for a more concise
-            representation of the <a href="#Event">Event</a>.</td>
+            representation of the <code>Event</code>.</td>
         <td>Optional</td>
     </tr>
     </tbody>

--- a/fragments/events/caliper-event-event.html
+++ b/fragments/events/caliper-event-event.html
@@ -1,11 +1,11 @@
 <h3>Caliper Event</h3>
 
-<img height="100%" width="100%" src="assets/caliper-event_model_no_title-v3.png" alt="Caliper Event"/>
+<img height="100%" width="100%" src="assets/caliper-event_model_no_title-v3.png" alt="Caliper Event">
 
 <p>A Caliper <a href="#Event">Event</a> is a generic type that describes the relationship established between an
     <code>action</code> and an <code>object</code>, formed as a result of a purposeful
     <a href="#actions">action</a> undertaken by the <code>action</code> at a particular moment in time and within a
-    given learning context.  The <a href="#Event">Event</a> properties <code>action</code>, <code>action</code> and
+    given learning context. The <a href="#Event">Event</a> properties <code>action</code>, <code>action</code> and
     <code>object</code> form a compact data structure that resembles an <a href="#rdf">RDF</a> triple linking a subject
     to an object via a predicate. A learner starting an assessment, annotating a reading, pausing a video, or
     posting a message to a forum, are examples of learning activities that Caliper models as events.</p>
@@ -19,14 +19,14 @@
 
 <p>The information model also seeks to describe the learning environment or context in which a learning
     activity is situated. Group affiliation, membership roles and status, recent navigation history,
-    supporting technology and session information can all be optionally represented.  An <a href="#entity">Entity</a>
+    supporting technology and session information can all be optionally represented. An <a href="#entity">Entity</a>
     generated as a result of the interaction between an <code>action</code> and an <code>object</code> can also be described;
     annotating a piece of digital content and producing an <a href="#Annotation">Annotation</a> is one such example.
     An <code>extensions</code> property is also provided so that implementers can add custom attributes not described
     by the model.</p>
 
 <p>Considered as a data structure an <a href="#Event">Event</a> constitutes an unordered set of key:value pairs that is
-    semi-structured by design. Optional attributes can be ignored when describing an <a href="#Event">Event</a>.  An
+    semi-structured by design. Optional attributes can be ignored when describing an <a href="#Event">Event</a>. An
     <a href="#entity">Entity</a> participating in an <a href="#Event">Event</a> can be represented as an object or as a
     string that corresponds to the <a href="#iriDef">IRI</a> defined for the <a href="#entity">Entity</a>.</p>
 
@@ -61,10 +61,10 @@
     </dd>
     <dt>Properties</dt>
     <dd>The base set of <a href="#Event">Event</a> properties or attributes is listed below. Each property MUST be
-        referenced only once.  The <code>id</code>, <code>type</code>, <code>action</code>, <code>action</code>,
+        referenced only once. The <code>id</code>, <code>type</code>, <code>action</code>, <code>action</code>,
         <code>object</code> and <code>eventTime</code> properties are required; all other properties are optional.
         Custom attributes not described by the model MAY be included but MUST be added to the <code>extensions</code>
-        property as a map of key:value pairs.  Properties with a value of *null* or empty SHOULD be excluded prior
+        property as a map of key:value pairs. Properties with a value of *null* or empty SHOULD be excluded prior
         to serialization.
     </dd>
 </dl>
@@ -83,7 +83,7 @@
         <td>id</td>
         <td><a href="#uuidDef">UUID</a></td>
         <td>The emitting application MUST provision the <a href="#Event">Event</a> with a <a href="#uuidDef">UUID</a>.
-            A version 4 <a href="#uuidDef">UUID</a> SHOULD be generated.  The UUID MUST be expressed as a
+            A version 4 <a href="#uuidDef">UUID</a> SHOULD be generated. The UUID MUST be expressed as a
             <a href="#urnDef">URN</a> using the form <code>urn:uuid:&lt;UUID&gt;</code> per
             <a href="#rfc4122">RFC 4122</a>.</td>
         <td>Required</td>
@@ -120,7 +120,7 @@
     <tr>
         <td>action</td>
         <td><a href="#termDef">Term</a></td>
-        <td>The action or predicate that binds the actor or subject to the object.  The <code>action</code> range is
+        <td>The action or predicate that binds the actor or subject to the object. The <code>action</code> range is
             limited to the set of <a href="#actions">actions</a> described in this specification or associated profiles
             and may be further constrained by the chosen <a href="#Event">Event</a> type. Only one <code>action</code>
             <a href="#termDef">Term</a> may be specified per <a href="#Event">Event</a>.</td>
@@ -153,7 +153,7 @@
     <tr>
         <td>generated</td>
         <td><a href="#Entity">Entity</a> | <a href="#iriDef">IRI</a></td>
-        <td>An <a href="#entity">Entity</a> created or generated as a result of the interaction.  The
+        <td>An <a href="#entity">Entity</a> created or generated as a result of the interaction. The
             <code>generated</code> value MUST be expressed either as an object or as a string corresponding to the
             generated entity's <a href="#iriDef">IRI</a>.</td>
         <td>Optional</td>

--- a/fragments/events/caliper-event-feedback.html
+++ b/fragments/events/caliper-event-feedback.html
@@ -1,8 +1,8 @@
 <h3>FeedbackEvent</h3>
 
-<img height="100%" width="100%" src="assets/caliper-feedback_event_ranked-v1p2.png" alt="Feedback Event Ranked"/>
+<img height="100%" width="100%" src="assets/caliper-feedback_event_ranked-v1p2.png" alt="Feedback Event Ranked">
 
-<img height="100%" width="100%" src="assets/caliper-feedback_event_commented-v1p2.png" alt="Feedback Event Commented"/>
+<img height="100%" width="100%" src="assets/caliper-feedback_event_commented-v1p2.png" alt="Feedback Event Commented">
 
 <p>A Caliper <code>FeedbackEvent</code> models a <code>Person</code> providing informal feedback
     on an <code>Entity</code>, typically a <code>DigitalResource</code> or another <code>Person</code>.

--- a/fragments/events/caliper-event-grade.html
+++ b/fragments/events/caliper-event-grade.html
@@ -1,0 +1,77 @@
+<h3>GradeEvent</h3>
+
+<img height="100%" width="100%" src="assets/caliper-grade_event_graded-v2.png" alt="GradeEvent Graded image">
+
+<p>A Caliper <code>GradeEvent</code> models scoring or grading activities performed by an
+    <a href="#Agent">Agent</a>, typically a <a href="#Person">Person</a> or a
+    <a href="#SoftwareApplication">SoftwareApplication</a>. The Caliper <code>GradeEvent</code> replaces the
+    deprecated <a href="#OutcomeEvent">OutcomeEvent</a>.
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd><a href="http://purl.imsglobal.org/caliper/GradeEvent">http://purl.imsglobal.org/caliper/GradeEvent</a></dd>
+    <dt>Term</dt>
+    <dd>GradeEvent</dd>
+    <dt>Supertype</dt>
+    <dd><a href="#Event">Event</a></dd>
+    <dt>Properties</dt>
+    <dd>The <code>GradeEvent</code> inherits all properties defined by its supertype <a href="#Event">Event</a>,
+        of which <code>id</code>, <code>type</code>, <code>actor</code>, <code>action</code>,
+        <code>object</code>, and <code>eventTime</code> are required. Additional profile-specific type and value
+        restrictions are described below:
+    </dd>
+</dl>
+
+<table class="data">
+    <thead>
+    <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Disposition</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>type</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The string value MUST be set to the <a href="#termDef">Term</a> <em>GradeEvent</em>.</td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>actor</td>
+        <td><a href="#Agent">Agent</a> | <a href="#iriDef">IRI</a></td>
+        <td>An <a href="#Agent">Agent</a>, typically <a href="#Person">Person</a> or
+            <a href="#SoftwareApplication">SoftwareApplication</a>, MUST be specified as the <code>actor</code>. The
+            <code>actor</code> value MUST be expressed either as an object or as a string corresponding to the actor's
+            <a href="#iriDef">IRI</a>.</td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>action</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The action or predicate that binds the <code>actor</code> or subject to the <code>object</code>. The value
+            range is limited to the <a href="#action-graded">Graded</a> action only.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>object</td>
+        <td><a href="#Attempt">Attempt</a> | <a href="#iriDef">IRI</a></td>
+        <td>The completed <a href="#Attempt">Attempt</a>. The <code>object</code> value MUST be expressed either as an
+            object or as a string corresponding to the object's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>generated</td>
+        <td><a href="#Score">Score</a> | <a href="#iriDef">IRI</a></td>
+        <td>The generated <a href="#Score">Score</a> SHOULD be provided. The <code>generated</code> value MUST be
+            expressed either as an object or as a string corresponding to the generated entity's
+            <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Optional</td>
+    </tr>
+    </tbody>
+</table>

--- a/fragments/events/caliper-event-grade.html
+++ b/fragments/events/caliper-event-grade.html
@@ -4,8 +4,7 @@
 
 <p>A Caliper <code>GradeEvent</code> models scoring or grading activities performed by an
     <a href="#Agent">Agent</a>, typically a <a href="#Person">Person</a> or a
-    <a href="#SoftwareApplication">SoftwareApplication</a>. The Caliper <code>GradeEvent</code> replaces the
-    deprecated <a href="#OutcomeEvent">OutcomeEvent</a>.
+    <a href="#SoftwareApplication">SoftwareApplication</a>.
 </p>
 
 <dl>

--- a/fragments/events/caliper-event-media.html
+++ b/fragments/events/caliper-event-media.html
@@ -1,0 +1,91 @@
+<h3>MediaEvent</h3>
+
+<img height="100%" width="100%" src="assets/caliper-media_event_paused-v2.png" alt="MediaEvent Paused image">
+
+<p>A Caliper <code>MediaEvent</code> models interactions between learners and rich content such as audio, images, and
+    video.
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd><a href="http://purl.imsglobal.org/caliper/MediaEvent">http://purl.imsglobal.org/caliper/MediaEvent</a></dd>
+    <dt>Term</dt>
+    <dd>MediaEvent</dd>
+    <dt>Supertype</dt>
+    <dd><a href="#Event">Event</a></dd>
+    <dt>Properties</dt>
+    <dd>The <code>MediaEvent</code> inherits all properties defined by its supertype <a href="#Event">Event</a>,
+        of which <code>id</code>, <code>type</code>, <code>actor</code>, <code>action</code>,
+        <code>object</code>, and <code>eventTime</code> are required. Additional profile-specific type and value
+        restrictions are described below:
+    </dd>
+</dl>
+
+<table class="data">
+    <thead>
+    <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Disposition</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>type</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The string value MUST be set to the <a href="#termDef">Term</a> <em>MediaEvent</em>.</td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>actor</td>
+        <td><a href="#Person">Person</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#Person">Person</a> who initiated the <code>action</code>. The <code>actor</code> value MUST
+            be expressed either as an object or as a string corresponding to the actor's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>action</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The action or predicate that binds the <code>actor</code> or subject to the <code>object</code>. The value
+            range is limited to the <a href="#action-started">Started</a>, <a href="#action-ended">Ended</a>,
+            <a href="#action-paused">Paused</a>, <a href="#action-resumed">Resumed</a>,
+            <a href="#action-restarted">Restarted</a>, <a href="#action-forwardedTo">ForwardedTo</a>,
+            <a href="#action-jumpedTo">JumpedTo</a>, <a href="#action-changedResolution">ChangedResolution</a>,
+            <a href="#action-changedSize">ChangedSize</a>, <a href="#action-changedSpeed">ChangedSpeed</a>,
+            <a href="#action-changedVolume">ChangedVolume</a>,
+            <a href="#action-enabledClosedCaptioning">EnabledClosedCaptioning</a>,
+            <a href="#action-disabledClosedCaptioning">DisabledClosedCaptioning</a>,
+            <a href="#action-enteredFullScreen">EnteredFullScreen</a>,
+            <a href="#action-exitedFullScreen">ExitedFullScreen</a>,
+            <a href="#action-muted">Muted</a>, <a href="#action-unmuted">Unmuted</a>,
+            <a href="#action-openedPopout">OpenedPopout</a>, and <a href="#action-closedPopout">ClosedPopout</a>
+            actions only.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>object</td>
+        <td><a href="#MediaObject">MediaObject</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#MediaObject">MediaObject</a> or a subtype that constitutes the <code>object</code> of the
+            interaction. The <code>object</code> value MUST be expressed either as an object or as a string
+            corresponding to the object's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>target</td>
+        <td><a href="#MediaLocation">MediaLocation</a> | <a href="#iriDef">IRI</a></td>
+        <td>If the <code>MediaEvent</code> <code>object</code> is an
+            <a href="#AudioObject">AudioObject</a> or <a href="#VideoObject">VideoObject</a>,
+            a <a href="#MediaLocation">MediaLocation</a> SHOULD be specified in order to provide the
+            <code>currentTime</code> in the audio or video stream that marks the action. If the
+            <code>currentTime</code> is specified, the value MUST be an ISO 8601 formatted duration, e.g.,
+            &quot;PT30M54S&quot;. The <code>target</code> value MUST be expressed either as an object or as a
+            string corresponding to the target entity's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Optional</td>
+    </tr>
+    </tbody>
+</table>

--- a/fragments/events/caliper-event-message.html
+++ b/fragments/events/caliper-event-message.html
@@ -1,0 +1,69 @@
+<h3>MessageEvent</h3>
+
+<img height="100%" width="100%" src="assets/caliper-message_event_posted-v2.png" alt="MessageEvent Posted image">
+
+<p>A Caliper <code>MessageEvent</code> describes a <a href="#Person">Person</a> posting a
+    <a href="#Message">Message</a> or marking a post as either read or unread.
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd><a href="http://purl.imsglobal.org/caliper/MessageEvent">http://purl.imsglobal.org/caliper/MessageEvent</a></dd>
+    <dt>Term</dt>
+    <dd>MessageEvent</dd>
+    <dt>Supertype</dt>
+    <dd><a href="#Event">Event</a></dd>
+    <dt>Properties</dt>
+    <dd>The <code>MessageEvent</code> inherits all properties defined by its supertype <a href="#Event">Event</a>,
+        of which <code>id</code>, <code>type</code>, <code>actor</code>, <code>action</code>,
+        <code>object</code>, and <code>eventTime</code> are required. Additional profile-specific type and value
+        restrictions are described below:
+    </dd>
+</dl>
+
+<table class="data">
+    <thead>
+    <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Disposition</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>type</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The string value MUST be set to the <a href="#termDef">Term</a> <em>MessageEvent</em>.</td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>actor</td>
+        <td><a href="#Person">Person</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#Person">Person</a> who initiated the <code>action</code>. The <code>actor</code> value MUST be
+            expressed either as an object or as a string corresponding to the actor's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>action</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The action or predicate that binds the <code>actor</code> or subject to the <code>object</code>. The value
+            range is limited to the <a href="#action-markedAsRead">MarkedAsRead</a>,
+            <a href="#action-markedAsUnRead">MarkedAsUnRead</a>, and <a href="#action-posted">Posted</a> actions only.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>object</td>
+        <td><a href="#Message">Message</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#Message">Message</a> that constitutes the <code>object</code> of the interaction. If the
+            <code>object</code> represents a <a href="#Message">Message</a> posted in reply to a previous post, the
+            prior post prompting the <a href="#Message">Message</a> SHOULD be referenced using the
+            <a href="#Message">Message</a> <code>replyTo</code> property. The <code>object</code> value MUST be
+            expressed either as an object or as a string corresponding to the object's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    </tbody>
+</table>

--- a/fragments/events/caliper-event-navigation-survey.html
+++ b/fragments/events/caliper-event-navigation-survey.html
@@ -1,6 +1,6 @@
 <h3>NavigationEvent</h3>
 
-<img height="100%" width="100%" src="assets/caliper-navigation_event_navigatedto-questionnaire-v1p1-extension.png" alt="NavigationEvent"/>
+<img height="100%" width="100%" src="assets/caliper-navigation_event_navigatedto-questionnaire-v1p1-extension.png" alt="NavigationEvent">
 
 <p>A Caliper <code>NavigationEvent</code> models an <code>actor</code> traversing a network of digital resources. When
     implementing the Survey Profile the <code>object</code> of the navigable interaction is limited to either a

--- a/fragments/events/caliper-event-navigation.html
+++ b/fragments/events/caliper-event-navigation.html
@@ -1,6 +1,6 @@
 <h3>NavigationEvent</h3>
 
-<img height="100%" width="100%" src="assets/caliper-navigation_event_navigatedto-v2.png" alt="NavigationEvent"/>
+<img height="100%" width="100%" src="assets/caliper-navigation_event_navigatedto-v2.png" alt="NavigationEvent">
 
 <p>A Caliper <code>NavigationEvent</code> models an <code>actor</code> traversing a network of digital resources.</p>
 

--- a/fragments/events/caliper-event-questionnaire.html
+++ b/fragments/events/caliper-event-questionnaire.html
@@ -1,6 +1,6 @@
 <h3>QuestionnaireEvent</h3>
 
-<img height="100%" width="100%" src="assets/caliper-questionnaire_event_started-v1p1-extension.png" alt="QuestionnaireEvent"/>
+<img height="100%" width="100%" src="assets/caliper-questionnaire_event_started-v1p1-extension.png" alt="QuestionnaireEvent">
 
 <p>A Caliper <code>QuestionnaireEvent</code> models activities associated with respondents or
     raters starting and submitting a <a href="#Questionnaire">Questionnaire</a>.
@@ -63,7 +63,7 @@
         <td><a href="#Questionnaire">Questionnaire</a> | <a href=
             "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
         >IRI</a></td>
-        <td>The <a href="#Questionnaire">Questionnaire</a> that the <code>actor</code> is taking.  The
+        <td>The <a href="#Questionnaire">Questionnaire</a> that the <code>actor</code> is taking. The
             <code>object</code> value MUST be expressed either as an object or as a string corresponding to the
             resource's IRI.</td>
         <td>Required</td>

--- a/fragments/events/caliper-event-questionnaireitem.html
+++ b/fragments/events/caliper-event-questionnaireitem.html
@@ -1,9 +1,9 @@
 <h3>QuestionnaireItemEvent</h3>
 
-<img height="100%" width="100%" src="assets/caliper-questionnaireitem_event_submitted-v1p1-extension.png" alt="QuestionnaireItemEvent"/>
+<img height="100%" width="100%" src="assets/caliper-questionnaireitem_event_submitted-v1p1-extension.png" alt="QuestionnaireItemEvent">
 
 <p>A Caliper <code>QuestionnaireItemEvent</code> models activities associated with
-    respondents or raters starting, completing or skipping a <a href="#QuestionnaireItem">QuestionnaireItem</a>.
+    respondents or raters starting, completing, or skipping a <a href="#QuestionnaireItem">QuestionnaireItem</a>.
 </p>
 
 <dl>
@@ -74,7 +74,7 @@
         <td><a href="#Response">Response</a> | <a href=
             "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
         >IRI</a></td>
-        <td>For a  <a href="#action-completed">Completed</a> action a generated <a href="#Response">Response</a> MAY
+        <td>For a <a href="#action-completed">Completed</a> action a generated <a href="#Response">Response</a> MAY
             be referenced. The <code>generated</code> value MUST be expressed either as an object or as a string
             corresponding to the <a href="#Response">Response</a> resource's IRI.</td>
         <td>Optional</td>

--- a/fragments/events/caliper-event-resourcemanagement.html
+++ b/fragments/events/caliper-event-resourcemanagement.html
@@ -1,11 +1,9 @@
 <h3>ResourceManagementEvent</h3>
 
 <img height="100%" width="100%" src="assets/caliper-resource_management_event_created-v1p2.png"
-     alt="ResourceManagementEvent"/>
+     alt="ResourceManagementEvent">
 
-<p>A Caliper <code>ResourceManagementEvent</code> models a <code>Person</code>
-    managing an <code>Entity</code>.
-</p>
+<p>A Caliper <code>ResourceManagementEvent</code> models a <code>Person</code> managing an <code>Entity</code>.</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/events/caliper-event-search.html
+++ b/fragments/events/caliper-event-search.html
@@ -1,6 +1,6 @@
 <h3>SearchEvent</h3>
 
-<img height="100%" width="100%" src="assets/caliper-search_event_searched-query_generated-v1p1.png" alt="Search Event"/>
+<img height="100%" width="100%" src="assets/caliper-search_event_searched-query_generated-v1p1.png" alt="Search Event">
 
 <p>A Caliper <code>SearchEvent</code> models a <code>Person</code> querying a resource for
     information, typically a <code>DigitalResource</code> or <code>SoftwareApplication</code>.

--- a/fragments/events/caliper-event-session.html
+++ b/fragments/events/caliper-event-session.html
@@ -1,0 +1,99 @@
+<h3>SessionEvent</h3>
+
+<img height="100%" width="100%" src="assets/caliper-session_event_loggedin-v2.png" alt="SessionEvent LoggedIn image">
+<img height="100%" width="100%" src="assets/caliper-session_event_loggedout-v2.png" alt="SessionEvent LoggedOut image">
+<img height="100%" width="100%" src="assets/caliper-session_event_timedout-v2.png" alt="SessionEvent TimedOut image">
+
+<p>A Caliper <code>SessionEvent</code> models the creation and subsequent termination of a user session established by a
+    <a href="#Person">Person</a> interacting with a <a href="#SoftwareApplication">SoftwareApplication</a>.
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd><a href="http://purl.imsglobal.org/caliper/SessionEvent">http://purl.imsglobal.org/caliper/SessionEvent</a></dd>
+    <dt>Term</dt>
+    <dd>SessionEvent</dd>
+    <dt>Supertype</dt>
+    <dd><a href="#Event">Event</a></dd>
+    <dt>Properties</dt>
+    <dd>The <code>SessionEvent</code> inherits all properties defined by its supertype <a href="#Event">Event</a>,
+        of which <code>id</code>, <code>type</code>, <code>actor</code>, <code>action</code>,
+        <code>object</code>, and <code>eventTime</code> are required. Additional profile-specific type and value
+        restrictions are described below:
+    </dd>
+</dl>
+
+<table class="data">
+    <thead>
+    <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Disposition</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>type</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The string value MUST be set to the <a href="#termDef">Term</a> <em>SessionEvent</em>.</td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>actor</td>
+        <td><a href="#Person">Person</a> | <a href="#SoftwareApplication">SoftwareApplication</a> |
+            <a href="#iriDef">IRI</a>
+        </td>
+        <td>The <a href="#Agent">Agent</a> who initiated the <code>action</code>. For
+            <a href="#action-loggedIn">LoggedIn</a> and <a href="#action-loggedOut">LoggedOut</a> actions a
+            <a href="#Person">Person</a> MUST be specified as the <code>actor</code>. For a
+            <a href="#action-timedOut">TimedOut</a> action a <a href="#SoftwareApplication">SoftwareApplication</a>
+            MUST be specified as the <code>actor</code>. The <code>actor</code> value MUST be expressed either as an
+            object or as a string corresponding to the actor's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>action</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The action or predicate that binds the <code>actor</code> or subject to the <code>object</code>. The value
+            range is limited to the <a href="#action-loggedIn">LoggedIn</a>, <a href="#action-loggedOut">LoggedOut</a>,
+            and <a href="#action-timedOut">TimedOut</a> actions only.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>object</td>
+        <td><a href="#Session">Session</a> | <a href="#SoftwareApplication">SoftwareApplication</a> |
+            <a href="#iriDef">IRI</a></td>
+        <td>For <a href="#action-loggedIn">LoggedIn</a> and <a href="#action-loggedOut">LoggedOut</a> actions a
+            <a href="#SoftwareApplication">SoftwareApplication</a> MUST be specified as the <code>object</code>. For a
+            <a href="#action-timedOut">TimedOut</a> action the <a href="#Session">Session</a> MUST be specified as the
+            object. The <code>object</code> value MUST be expressed either as an object or as a string corresponding to
+            the object's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>target</td>
+        <td><a href="#DigitalResource">DigitalResource</a> | <a href="#iriDef">IRI</a></td>
+        <td>When logging in to a <a href="#SoftwareApplication">SoftwareApplication</a>, if the actor is attempting to
+            access a particular <a href="#DigitalResource">DigitalResource</a> it MAY be designated as the
+            <code>target</code> of the interaction. The <code>target</code> value MUST be expressed either as an object
+            or as a string corresponding to the target entity's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Optional</td>
+    </tr>
+    <tr>
+        <td>referrer</td>
+        <td><a href="#DigitalResource">DigitalResource</a> | <a href="#SoftwareApplication">SoftwareApplication</a> |
+            <a href="#iriDef">IRI</a>
+        </td>
+        <td>The <a href="#DigitalResource">DigitalResource</a> or <a href="#SoftwareApplication">SoftwareApplication</a>
+            that constitutes the referring context MAY be specified as the <code>referrer</code>. The
+            <code>referrer</code> value MUST be expressed either as an object or as a string corresponding to the
+            referrer's <a href="#iriDef">IRI</a>.</td>
+        <td>Optional</td>
+    </tr>
+    </tbody>
+</table>

--- a/fragments/events/caliper-event-survey.html
+++ b/fragments/events/caliper-event-survey.html
@@ -1,6 +1,6 @@
 <h3>SurveyEvent</h3>
 
-<img height="100%" width="100%" src="assets/caliper-survey_event_optedin-v1p1-extension.png" alt="SurveyEvent"/>
+<img height="100%" width="100%" src="assets/caliper-survey_event_optedin-v1p1-extension.png" alt="SurveyEvent">
 
 <p>A Caliper <code>SurveyEvent</code> models activities associated with calls to participate in a
     <a href="#Survey">Survey</a>.

--- a/fragments/events/caliper-event-surveyinvitation.html
+++ b/fragments/events/caliper-event-surveyinvitation.html
@@ -1,6 +1,6 @@
 <h3>SurveyInvitationEvent</h3>
 
-<img height="100%" width="100%" src="assets/caliper-survey_invitation_event_sent-v1p1-extension.png" alt="SurveyInvitationEvent"/>
+<img height="100%" width="100%" src="assets/caliper-survey_invitation_event_sent-v1p1-extension.png" alt="SurveyInvitationEvent">
 
 <p>A Caliper <code>SurveyInvitationEvent</code> models activities associated with calls to participate
     in a <a href="#Survey">Survey</a>.

--- a/fragments/events/caliper-event-thread.html
+++ b/fragments/events/caliper-event-thread.html
@@ -1,0 +1,68 @@
+<h3>ThreadEvent</h3>
+
+<img height="100%" width="100%" src="assets/caliper-thread_event_markedasread-v2.png"
+     alt="ThreadEvent MarkedAsRead image">
+
+<p>A Caliper <code>ThreadEvent</code> models an actor interacting with a <a href="#Forum">Forum</a> thread or
+    topic.
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd><a href="http://purl.imsglobal.org/caliper/ThreadEvent">http://purl.imsglobal.org/caliper/ThreadEvent</a></dd>
+    <dt>Term</dt>
+    <dd>ThreadEvent</dd>
+    <dt>Supertype</dt>
+    <dd><a href="#Event">Event</a></dd>
+    <dt>Properties</dt>
+    <dd>The <code>ThreadEvent</code> inherits all properties defined by its supertype <a href="#Event">Event</a>,
+        of which <code>id</code>, <code>type</code>, <code>actor</code>, <code>action</code>,
+        <code>object</code>, and <code>eventTime</code> are required. Additional profile-specific type and value
+        restrictions are described below:
+    </dd>
+</dl>
+
+<table class="data">
+    <thead>
+    <tr>
+        <th>Property</th>
+        <th>Type</th>
+        <th>Description</th>
+        <th>Disposition</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>type</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The string value MUST be set to the term <em>ThreadEvent</em>.</td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>actor</td>
+        <td><a href="#Person">Person</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#Person">Person</a> who initiated the <code>action</code>. The <code>actor</code> value MUST
+            be expressed either as an object or as a string corresponding to the actor's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>action</td>
+        <td><a href="#termDef">Term</a></td>
+        <td>The action or predicate that binds the <code>actor</code> or subject to the <code>object</code>. The value
+            range is limited to the <a href="#action-markedAsRead">MarkedAsRead</a> and
+            <a href="#action-markedAsUnRead">MarkedAsUnRead</a> actions only.
+        </td>
+        <td>Required</td>
+    </tr>
+    <tr>
+        <td>object</td>
+        <td><a href="#Thread">Thread</a> | <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#Thread">Thread</a> that constitutes the <code>object</code> of the interaction. The
+            <code>object</code> value MUST be expressed either as an object or as a string corresponding to the
+            object's <a href="#iriDef">IRI</a>.
+        </td>
+        <td>Required</td>
+    </tr>
+    </tbody>
+</table>

--- a/fragments/events/caliper-event-toollaunch.html
+++ b/fragments/events/caliper-event-toollaunch.html
@@ -1,6 +1,6 @@
 <h3>ToolLaunchEvent</h3>
 
-<img height="100%" width="100%" src="assets/caliper-tool_launch_event_launched-v1p2.png" alt="ToolLaunchEvent"/>
+<img height="100%" width="100%" src="assets/caliper-tool_launch_event_launched-v1p2.png" alt="ToolLaunchEvent">
 
 <p>The Tool Launch Profile is provisioned with a single <code>ToolLaunchEvent</code>
     for describing tool launches, typically occuring in the context of an LMS.</p>

--- a/fragments/events/caliper-event-tooluse.html
+++ b/fragments/events/caliper-event-tooluse.html
@@ -1,5 +1,5 @@
 <h3>ToolUseEvent</h3>
-<img height="100%" width="100%" src="assets/caliper-tool_use_event_used_progress-v1p2.png" alt="ToolUseEvent"/>
+<img height="100%" width="100%" src="assets/caliper-tool_use_event_used_progress-v1p2.png" alt="ToolUseEvent">
 
 <p>A Caliper <a href="#ToolUseEvent">ToolUseEvent</a> models a <a href="#Person">Person</a> using a learning
     tool in a way that the tool's creators have

--- a/fragments/events/caliper-event-view-questionnaire.html
+++ b/fragments/events/caliper-event-view-questionnaire.html
@@ -1,6 +1,6 @@
 <h3>ViewEvent</h3>
 
-<img height="100%" width="100%" src="assets/caliper-view_event_viewed-questionnaire-v1p1-extension.png" alt="ViewEvent"/>
+<img height="100%" width="100%" src="assets/caliper-view_event_viewed-questionnaire-v1p1-extension.png" alt="ViewEvent">
 
 <p>A Caliper <code>ViewEvent</code> models an actor's examination of digital content whenever
     the activity emphasizes thoughtful observation or study as opposed to the mere retrieval of a

--- a/fragments/events/caliper-event-view.html
+++ b/fragments/events/caliper-event-view.html
@@ -1,6 +1,6 @@
 <h3>ViewEvent</h3>
 
-<img height="100%" width="100%" src="assets/caliper-view_event_viewed-v2.png" alt="ViewEvent"/>
+<img height="100%" width="100%" src="assets/caliper-view_event_viewed-v2.png" alt="ViewEvent">
 
 <p>A Caliper <code>ViewEvent</code> models an actor's examination of digital content whenever the activity emphasizes
     thoughtful observation or study as opposed to the mere retrieval of a resource.


### PR DESCRIPTION
This PR includes five new HTML event docs under assets/fragments: caliper-event-grade.html, caliper-event-media.html, caliper-event-message.html, caliper-event-session.html, and caliper-event-thread.html. I also checked the other event docs for three formatting issues: double spaces between sentences, text in table fields starting with lowercase letters, and the closing forward slash in the img tags. Double spaces were made into one space, lowercase letters were capitalized, and slashes were removed (the last to just keep things consistent). Below I have also flagged noteworthy decisions and questions. Please feel free to have me reverse course and/or act on any of them.

1) The mention of a deprecated OutcomeEvent subtype was deleted from the GradeEvent doc.

2) In the MediaEvent doc, rather than list the subtypes of MediaObject for the supported values as in v1p1, I changed the table text to say "MediaObject or a subtype".

3) I saw there was a fair amount of internal linking to Event in the generic Event HTML doc. Do you want me to change those to be wrapped in code tags?

4) I'm seeing that caliper-event-navigation-survey.html and caliper-event-view-questionnaire.html are not referenced yet in the respec doc. Do we have to handle those differently? (Remember some discussion about this but not the particulars).