### PR TITLE
New batch of HTML docs

### DIFF
--- a/caliper-spec-respec.html
+++ b/caliper-spec-respec.html
@@ -1239,19 +1239,30 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superceded by new SearchEvent.
         <section id="action-archived" data-include="fragments/actions/caliper-action-archived.html"></section>
         <section id="action-attached" data-include="fragments/actions/caliper-action-attached.html"></section>
         <section id="action-bookmarked" data-include="fragments/actions/caliper-action-bookmarked.html"></section>
+        <section id="action-changedResolution" data-include="fragments/actions/caliper-action-changedresolution.html"></section>
+        <section id="action-changedSize" data-include="fragments/actions/caliper-action-changedsize.html"></section>
+        <section id="action-changedSpeed" data-include="fragments/actions/caliper-action-changedspeed.html"></section>
+        <section id="action-changedVolume" data-include="fragments/actions/caliper-action-changedvolume.html"></section>
+        <section id="action-classified" data-include="fragments/actions/caliper-action-classified.html"></section>
+        <section id="action-closedPopout" data-include="fragments/actions/caliper-action-closedpopout.html"></section>
         <section id="action-commented" data-include="fragments/actions/caliper-action-commented.html"></section>
         <section id="action-completed" data-include="fragments/actions/caliper-action-completed.html"></section>
         <section id="action-copied" data-include="fragments/actions/caliper-action-copied.html"></section>
         <section id="action-created" data-include="fragments/actions/caliper-action-created.html"></section>
+        <section id="action-deactivated" data-include="fragments/actions/caliper-action-deactivated.html"></section>
         <section id="action-declined" data-include="fragments/actions/caliper-action-declined.html"></section>
         <section id="action-deleted" data-include="fragments/actions/caliper-action-deleted.html"></section>
         <section id="action-described" data-include="fragments/actions/caliper-action-described.html"></section>
+        <section id="action-disabledClosedCaptioning" data-include="fragments/actions/caliper-action-disabledclosedcaptioning.html"></section>
+        <section id="action-disliked" data-include="fragments/actions/caliper-action-disliked.html"></section>
         <section id="action-downloaded" data-include="fragments/actions/caliper-action-downloaded.html"></section>
+        <section id="action-enabledClosedCaptioning" data-include="fragments/actions/caliper-action-enabledClosedCaptioning.html"></section>
+        <section id="action-ended" data-include="fragments/actions/caliper-action-ended.html"></section>
         <section id="action-launched" data-include="fragments/actions/caliper-action-launched.html"></section>
         <section id="action-modified" data-include="fragments/actions/caliper-action-modified.html"></section>
-        <section id="action-navigatedto" data-include="fragments/actions/caliper-action-navigatedto.html"></section>
-        <section id="action-optedin" data-include="fragments/actions/caliper-action-optedin.html"></section>
-        <section id="action-optedout" data-include="fragments/actions/caliper-action-optedout.html"></section>
+        <section id="action-navigatedTo" data-include="fragments/actions/caliper-action-navigatedto.html"></section>
+        <section id="action-optedIn" data-include="fragments/actions/caliper-action-optedin.html"></section>
+        <section id="action-optedOut" data-include="fragments/actions/caliper-action-optedout.html"></section>
         <section id="action-printed" data-include="fragments/actions/caliper-action-printed.html"></section>
         <section id="action-published" data-include="fragments/actions/caliper-action-published.html"></section>
         <section id="action-ranked" data-include="fragments/actions/caliper-action-ranked.html"></section>

--- a/fragments/actions/caliper-action-abandoned.html
+++ b/fragments/actions/caliper-action-abandoned.html
@@ -1,5 +1,6 @@
 <h3>Abandoned</h3>
-<p>Forsake, leave behind.</p>
+<p>The <em>Abandoned</em> action signals that some <a href="#Entity">Entity</a> has been left behind or
+    unfinished. ... TO DO</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-accepted.html
+++ b/fragments/actions/caliper-action-accepted.html
@@ -1,5 +1,7 @@
 <h3>Accepted</h3>
-<p>Give an affirmative reply to. Inverse of <a href="#action-declined">Declined</a>.</p>
+<p>The <em>Accepted</em> action signals that an affirmative reply has been given. Inverse of
+    <a href="#action-declined">Declined</a>. ...TO DO
+</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-activated.html
+++ b/fragments/actions/caliper-action-activated.html
@@ -1,5 +1,7 @@
 <h3>Activated</h3>
-<p>Make active or more active. Inverse of <a href="#action-deactivated">Deactivated</a>.</p>
+<p>The <em>Activated</em> action signals that some <a href="#Entity">Entity</a> has been made active. Inverse of
+    <a href="#action-deactivated">Deactivated</a>. ...TO DO
+</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-added.html
+++ b/fragments/actions/caliper-action-added.html
@@ -1,6 +1,7 @@
 <h3>Added</h3>
-<p>Make an addition (to); join or combine or unite with others; increase the quality, quantity, size or scope of</a>.
-    Inverse of <a href="#action-removed">Removed</a>.</p>
+<p>The <em>Added</em> action signals the addition of some <a href="#Entity">Entity</a>. Inverse of
+    <a href="#action-removed">Removed</a>. ...TO DO
+</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-archived.html
+++ b/fragments/actions/caliper-action-archived.html
@@ -1,5 +1,5 @@
 <h3>Archived</h3>
-The <em>Archived</em> action signals that a resource has been put into long-term storage.
+<p>The <em>Archived</em> action signals that an <a href="#Entity">Entity</a> has been put into long-term storage.</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-attached.html
+++ b/fragments/actions/caliper-action-attached.html
@@ -1,5 +1,6 @@
 <h3>Attached</h3>
-<p>Cause to be attached.</p>
+<p>The <em>Attached</em> action signals that some <a href="#Entity">Entity</a> has been attached to some other
+    <a href="#Entity">Entity</a>. ... TO DO</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-bookmarked.html
+++ b/fragments/actions/caliper-action-bookmarked.html
@@ -1,6 +1,6 @@
 <h3>Bookmarked</h3>
-<p>A marker that specifies a location of interest in a <a href="#DigitalResource">DigitalResource</a> that is recorded
-    for later retrieval.
+<p>The <em>Bookmarked</em> action signals that some location of interest within a
+    <a href="#DigitalResource">DigitalResource</a>has been labeled or flagged. ...TO DO
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-changedresolution.html
+++ b/fragments/actions/caliper-action-changedresolution.html
@@ -1,0 +1,18 @@
+<h3>ChangedResolution</h3>
+<p>The <em>ChangedResolution</em> action signals that the number of pixels per square inch on a comptuer-generated
+   display has been changed or adjusted. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/ChangedResolution</dd>
+    <dt>Term</dt>
+    <dd>ChangedResolution</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200126072-v">Cause to change; make different; cause a
+        transformation</a> of <a href="http://wordnet-rdf.princeton.edu/wn31/111526370-n">the number of pixels per
+        square inch on a computer-generated display</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-changedsize.html
+++ b/fragments/actions/caliper-action-changedsize.html
@@ -1,0 +1,16 @@
+<h3>ChangedSize</h3>
+<p>The <em>ChangedSize</em> action signals that the magnitude of some thing has changed. ...TO DO</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/ChangedSize</dd>
+    <dt>Term</dt>
+    <dd>ChangedSize</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200126072-v">Cause to change; make different; cause a
+        transformation</a> of <a href="http://wordnet-rdf.princeton.edu/wn31/105106204-n">the physical magnitude of
+        something</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-changedspeed.html
+++ b/fragments/actions/caliper-action-changedspeed.html
@@ -1,0 +1,16 @@
+<h3>ChangedSpeed</h3>
+<p>The <em>ChangedSpeed</em> action signals an altering of the rate at at which something happens. ...TO DO</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/ChangedSpeed</dd>
+    <dt>Term</dt>
+    <dd>ChangedSpeed</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200126072-v">Cause to change; make different; cause a
+        transformation</a> of the <a href="http://wordnet-rdf.princeton.edu/wn31/105065291-n">rate at which
+        something happens</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-changedvolume.html
+++ b/fragments/actions/caliper-action-changedvolume.html
@@ -1,0 +1,18 @@
+<h3>ChangedVolume</h3>
+<p>The <em>ChangedVolume</em> action signals an altering of the magnitude of sound originating from or related to some
+    <a href="#Entity">Entity</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/ChangedVolume</dd>
+    <dt>Term</dt>
+    <dd>ChangedVolume</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200126072-v">Cause to change; make different; cause a
+        transformation</a> of <a href="http://wordnet-rdf.princeton.edu/wn31/104997456-n">the magnitude of sound
+        (usually in a specified direction)</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-classified.html
+++ b/fragments/actions/caliper-action-classified.html
@@ -1,0 +1,15 @@
+<h3>Classified</h3>
+<p>The <em>Classified</em> action signals that some <a href="#Entity">Entity</a> has been placed or assigned to some
+    class, group, kind, or type. ... TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Classified</dd>
+    <dt>Term</dt>
+    <dd>Classified</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200741667-v">Assign to a class or kind</a>.</dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-closedpopout.html
+++ b/fragments/actions/caliper-action-closedpopout.html
@@ -1,0 +1,17 @@
+<h3>ClosedPopout</h3>
+<p>The <em>ClosedPopout</em> action signals that a video popout has been closed. Inverse of
+    <a href="#action-openedPopout">OpenedPopout</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/ClosedPopout</dd>
+    <dt>Term</dt>
+    <dd>ClosedPopout</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201349660-v">Close or shut</a> a video popout. Inverse of
+        <a href="#action-openedPopout">OpenedPopout</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-commented.html
+++ b/fragments/actions/caliper-action-commented.html
@@ -1,6 +1,7 @@
 <h3>Commented</h3>
-The <em>Commented</em> action signals that qualitative feedback in the form of a
-<a href="#entity-comment">Comment</a> has been provided.
+<p>The <em>Commented</em> action signals that qualitative feedback in the form of a
+    <a href="#entity-Comment">Comment</a> has been provided.
+</p>
 
 <dl>
     <dt>IRI</dt>
@@ -8,7 +9,7 @@ The <em>Commented</em> action signals that qualitative feedback in the form of a
     <dt>Term</dt>
     <dd>Commented</dd>
     <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201060446-v" rel="nofollow">Make or
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201060446-v">Make or
         write a comment on</a>.
     </dd>
     <dt>Supported by</dt>

--- a/fragments/actions/caliper-action-completed.html
+++ b/fragments/actions/caliper-action-completed.html
@@ -1,6 +1,7 @@
 <h3>Completed</h3>
-<p>Set in motion, cause to start, commence.</p>
-
+<p>The <em>Completed</em> action signals that an <a href="#Entity">Entity</a>, or the work or activity
+    associated with it, has been finished. ...TO DO
+</p>
 <dl>
     <dt>IRI</dt>
     <dd>https://purl.imsglobal.org/caliper/actions/Completed</dd>

--- a/fragments/actions/caliper-action-copied.html
+++ b/fragments/actions/caliper-action-copied.html
@@ -1,5 +1,5 @@
 <h3>Copied</h3>
-The <em>Copied</em> action signals that a resource has been duplicated.
+<p>The <em>Copied</em> action signals that a resource has been duplicated.</p>
 
 <dl>
     <dt>IRI</dt>
@@ -7,9 +7,7 @@ The <em>Copied</em> action signals that a resource has been duplicated.
     <dt>Term</dt>
     <dd>Copied</dd>
     <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201697776-v" rel="nofollow">Make a
-        replica of</a>.
-    </dd>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201697776-v">Make a replica of</a>.</dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-created.html
+++ b/fragments/actions/caliper-action-created.html
@@ -1,5 +1,7 @@
 <h3>Created</h3>
-The <em>Created</em> action signals that a resource has been brought into existence.
+<p>The <em>Created</em> action signals that a resource has been brought into existence. Inverse of
+   <a href="#action-deleted">Deleted</a>. ... TO DO
+</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-deactivated.html
+++ b/fragments/actions/caliper-action-deactivated.html
@@ -1,0 +1,17 @@
+<h3>Deactivated</h3>
+<p>The <em>Deactivated</em> action signals that some <a href="#Entity">Entity</a> has been made inactive. Inverse of
+    <a href="#action-activated">Activated</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Deactivated</dd>
+    <dt>Term</dt>
+    <dd>Deactivated</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200191849-v">Make inactive</a>. Inverse of
+        <a href="#action-activated">Activated</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#AssignableEvent">AssignableEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-declined.html
+++ b/fragments/actions/caliper-action-declined.html
@@ -1,5 +1,7 @@
 <h3>Declined</h3>
-<p>Refuse to accept. Inverse of <a href="#action-accepted">Accepted</a>.</p>
+<p>The <em>Declined</em> action signals that some option or task was refused or declined. Inverse of
+    <a href="#action-accepted">Accepted</a>.
+</p>
 
 <dl>
     <dt>IRI</dt>

--- a/fragments/actions/caliper-action-deleted.html
+++ b/fragments/actions/caliper-action-deleted.html
@@ -1,5 +1,7 @@
 <h3>Deleted</h3>
-The <em>Deleted</em> action signals that a resource has been removed permanently from a system.
+<p>The <em>Deleted</em> action signals that a resource has been removed permanently from a system. Inverse of
+    <a href="#action-created">Created</a>.
+</p>
 
 <dl>
     <dt>IRI</dt>
@@ -7,8 +9,8 @@ The <em>Deleted</em> action signals that a resource has been removed permanently
     <dt>Term</dt>
     <dd>Deleted</dd>
     <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201001860-v" rel="nofollow">Wipe out
-        digitally</a>. Inverse of <a href="#action-created">Created</a>.
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201001860-v">Wipe out digitally</a>. Inverse of
+        <a href="#action-created">Created</a>.
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>

--- a/fragments/actions/caliper-action-described.html
+++ b/fragments/actions/caliper-action-described.html
@@ -1,5 +1,5 @@
 <h3>Described</h3>
-The <em>Described</em> action signals that a description of a resource has been provided.
+<p>The <em>Described</em> action signals that a description of a resource has been provided.</p>
 
 <dl>
     <dt>IRI</dt>
@@ -7,7 +7,7 @@ The <em>Described</em> action signals that a description of a resource has been 
     <dt>Term</dt>
     <dd>Described</dd>
     <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200989103-v" rel="nofollow">Give a
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200989103-v">Give a
         description of</a>.
     </dd>
     <dt>Supported by</dt>

--- a/fragments/actions/caliper-action-disabledclosedcaptioning.html
+++ b/fragments/actions/caliper-action-disabledclosedcaptioning.html
@@ -1,0 +1,19 @@
+<h3>DisabledClosedCaptioning</h3>
+<p>The <em>DisabledClosedCaptioning</em> action signals that the option for visual display of transcriptions of audio
+    content has been turned off or disabled. Inverse of <a href="#enabledClosedCaptioning">EnabledClosedCaptioning</a>.
+    ... TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/DisabledClosedCaptioning</dd>
+    <dt>Term</dt>
+    <dd>DisabledClosedCaptioning</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200513267-v">Render unable to perform</a> the visual display of
+        a plain text transcription of audio output. Inverse of
+        <a href="#enabledClosedCaptioning">EnabledClosedCaptioning</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-disliked.html
+++ b/fragments/actions/caliper-action-disliked.html
@@ -1,0 +1,17 @@
+<h3>Disliked</h3>
+<p>The <em>Disliked</em> action signals that a <a href="#Person">Person</a> indicated their dislike or disapproval of an
+    <a href="#Entity">Entity</a>. Inverse of <a href="#action-liked">Liked</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Disliked</dd>
+    <dt>Term</dt>
+    <dd>Disliked</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201780648-v">Have or feel a dislike or distaste for</a>.
+        Inverse of <a href="#action-liked">Liked</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-downloaded.html
+++ b/fragments/actions/caliper-action-downloaded.html
@@ -1,6 +1,7 @@
 <h3>Downloaded</h3>
-The <em>Downloaded</em> action signals that a copy of the resource has been transferred from
-a central or primary system to a remote or secondary system.
+<p>The <em>Downloaded</em> action signals that a copy of the resource has been transferred from a central or primary
+    system to a remote or secondary system. Inverse of <a href="#action-uploaded">Uploaded</a>.
+</p>
 
 <dl>
     <dt>IRI</dt>
@@ -8,9 +9,9 @@ a central or primary system to a remote or secondary system.
     <dt>Term</dt>
     <dd>Downloaded</dd>
     <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/02233704-v" rel="nofollow">Transfer a
-        file or program from a central computer to a smaller computer or to a computer at a
-        remote location</a>. Inverse of <a href="#action-uploaded">Uploaded</a>.
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/02233704-v">Transfer a file or program from a central computer
+        to a smaller computer or to a computer at a remote location</a>. Inverse of
+        <a href="#action-uploaded">Uploaded</a>.
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>

--- a/fragments/actions/caliper-action-enabledclosedcaptioning.html
+++ b/fragments/actions/caliper-action-enabledclosedcaptioning.html
@@ -1,0 +1,19 @@
+<h3>EnabledClosedCaptioning</h3>
+<p>The <em>EnabledClosedCaptioning</em> action signals that the option for visual display of transcriptions of audio
+    content has been turned on or enabled. Inverse of <a href="#action-disabledClosedCaptioning">DisabledClosedCaptioning</a>.
+    ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/EnabledClosedCaptioning</dd>
+    <dt>Term</dt>
+    <dd>EnabledClosedCaptioning</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200513958-v">Render capable or able</a> the visual display of a
+        plain text transcription of audio output. Inverse of
+        <a href="#action-disabledClosedCaptioning">DisabledClosedCaptioning</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-ended.html
+++ b/fragments/actions/caliper-action-ended.html
@@ -1,0 +1,17 @@
+<h3>Ended</h3>
+<p>The <em>Ended</em> action signals that a process, task, or experience has been brought to an end. Inverse of
+    <a href="#action-started">Started</a>. ...TO DO.
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Ended</dd>
+    <dt>Term</dt>
+    <dd>Ended</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200353480-v">Bring to an end or halt</a>. Inverse of
+        <a href="#action-started">Started</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-optedout.html
+++ b/fragments/actions/caliper-action-optedout.html
@@ -1,5 +1,5 @@
 <h3>OptedOut</h3>
-<p>Decline to participate in a survey. Inverse of <a href="#action-opted-in">OptedIn</a>.</p>
+<p>Decline to participate in a survey. Inverse of <a href="#action-optedIn">OptedIn</a>.</p>
 
 <dl>
     <dt>IRI</dt>
@@ -8,7 +8,7 @@
     <dd>OptedOut</dd>
     <dt>Wiktionary Gloss</dt>
     <dd><a href="https://en.wiktionary.org/w/index.php?title=opt_out&oldid=50769215">To choose not to participate
-        in something.</a> Inverse of <a href="#action-opted-in">OptedIn</a>.
+        in something.</a> Inverse of <a href="#action-optedIn">OptedIn</a>.
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#SurveyEvent">SurveyEvent</a>

--- a/fragments/events/caliper-event-navigation.html
+++ b/fragments/events/caliper-event-navigation.html
@@ -31,15 +31,14 @@
     <tbody>
     <tr>
         <td>type</td>
-        <td><a href="https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#termDef"
-        >Term</a></td>
+        <td><a href="#termDef">Term</a></td>
         <td>The string value MUST be set to <em>NavigationEvent</em>.</td>
         <td>Required</td>
     </tr>
     <tr>
         <td>actor</td>
         <td><a href="#Person">Person</a> | <a href=
-          "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
+          "#iriDef"
         >IRI</a></td>
         <td>The <a href="#Person">Person</a> who initiated the action. The <code>actor</code> value MUST
             be expressed either as an object or as a string corresponding to the actor's IRI.</td>
@@ -47,20 +46,18 @@
     </tr>
     <tr>
         <td>action</td>
-        <td><a href="https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#termDef"
+        <td><a href="#termDef"
         >Term</a></td>
         <td>The action or predicate that binds the <code>actor</code> or subject to the
-            <code>object</code>. The value range is limited to the actions: <a href="#action-navigatedto">NavigatedTo</a>.</td>
+            <code>object</code>. The value range is limited to the actions: <a href="#action-navigatedTo">NavigatedTo</a>.</td>
         <td>Required</td>
     </tr>
     <tr>
         <td>object</td>
         <td><a href="#DigitalResource">DigitalResource</a> |
-            <a href="#Softwareapplication">SoftwareApplication</a> |
-            <a href=
-               "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
-            >IRI</a></td>
-        <td>The <a href="#DigitalResource">DigitalResource</a> or <a href="#Softwareapplication">SoftwareApplication</a>
+            <a href="#SoftwareApplication">SoftwareApplication</a> |
+            <a href="#iriDef">IRI</a></td>
+        <td>The <a href="#DigitalResource">DigitalResource</a> or <a href="#SoftwareApplication">SoftwareApplication</a>
             to which the <code>actor</code> navigated. The <code>object</code> value MUST be expressed either as
             an object or as a string corresponding to the resource's IRI.</td>
         <td>Required</td>
@@ -68,9 +65,8 @@
     <tr>
         <td>referrer</td>
         <td><a href="#DigitalResource">DigitalResource</a> |
-            <a href="#Softwareapplication">SoftwareApplication</a> |
-            <a href=
-               "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
+            <a href="#SoftwareApplication">SoftwareApplication</a> |
+            <a href="#iriDef"
             >IRI</a></td>
         <td>The <code>DigitalResource</code> or <code>SoftwareApplication</code> that constitutes the
             referring context. The <code>referrer</code> value MUST be expressed either as an object

--- a/fragments/events/caliper-event-survey.html
+++ b/fragments/events/caliper-event-survey.html
@@ -33,16 +33,14 @@
     <tbody>
     <tr>
         <td>type</td>
-        <td><a href=
-           "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#termDef"
+        <td><a href="#termDef"
         >Term</a></td>
         <td>The string value MUST be set to <em>SurveyEvent</em>.</td>
         <td>Required</td>
     </tr>
     <tr>
         <td>actor</td>
-        <td><a href="#Person">Person</a> | <a href=
-          "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
+        <td><a href="#Person">Person</a> | <a href="#iriDef"
         >IRI</a></td>
         <td>The <a href="#Person">Person</a> who initiated the action. The <code>actor</code> value MUST
             be expressed either as an object or as a string corresponding to the actor's IRI.</td>
@@ -50,20 +48,18 @@
     </tr>
     <tr>
         <td>action</td>
-        <td><a href=
-           "https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#termDef"
+        <td><a href="#termDef"
         >Term</a></td>
         <td>The action or predicate that binds the <code>actor</code> or subject to the
-            <code>object</code>. The value range is limited to the actions: <a href="#action-optedin">OptedIn</a> or
-            <a href="#action-optedout">OptedOut</a>.
+            <code>object</code>. The value range is limited to the actions: <a href="#action-optedIn">OptedIn</a> or
+            <a href="#action-optedOut">OptedOut</a>.
             </code>
             .</td>
         <td>Required</td>
     </tr>
     <tr>
         <td>object</td>
-        <td><a href="#entity-survey">Survey</a> |
-            <a href="https://www.imsglobal.org/sites/default/files/caliper/v1p1/caliper-spec-v1p1/caliper-spec-v1p1.html#iriDef"
+        <td><a href="#Survey">Survey</a> | <a href="#iriDef"
             >IRI</a></td>
         <td>The <code>Survey</code> to which the <code>actor</code> is opting into or out of. The <code>object</code>
             value MUST be expressed either as an object or as a string corresponding to the resource's IRI.</td>


### PR DESCRIPTION
This PR includes 11 new HTML docs for actions from the 1.1 spec. Some edits and formatting changes were also made to existing action docs. When definitions at the top of each document were re-written, "...TO DO" was added afterward for simple review in the future. Links with multiple words (e.g. "#action-navigatedTo") were made to use camel-case spelling in section tags, and references to them in the Event docs (MediaEvent, SurveyEvent, and NavigationEvent) were checked and corrected. Some other links to Entities in the Event docs were corrected.