### PR TITLE
Adding next 10 action docs and refs to respec

### DIFF
--- a/caliper-spec-respec.html
+++ b/caliper-spec-respec.html
@@ -1320,7 +1320,17 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superceded by new SearchEvent.
         <section id="action-downloaded" data-include="fragments/actions/caliper-action-downloaded.html"></section>
         <section id="action-enabledClosedCaptioning" data-include="fragments/actions/caliper-action-enabledClosedCaptioning.html"></section>
         <section id="action-ended" data-include="fragments/actions/caliper-action-ended.html"></section>
+        <section id="action-enteredFullScreen" data-include="fragments/actions/caliper-action-enteredfullscreen.html"></section>
+        <section id="action-exitedFullScreen" data-include="fragments/actions/caliper-action-exitedfullscreen.html"></section>
+        <section id="action-forwardedTo" data-include="fragments/actions/caliper-action-forwardedto.html"></section>
+        <section id="action-graded" data-include="fragments/actions/caliper-action-graded.html"></section>
+        <section id="action-hid" data-include="fragments/actions/caliper-action-hid.html"></section>
+        <section id="action-highlighted" data-include="fragments/actions/caliper-action-highlighted.html"></section>
+        <section id="action-identified" data-include="fragments/actions/caliper-action-identified.html"></section>
+        <section id="action-jumpedTo" data-include="fragments/actions/caliper-action-jumpedto.html"></section>
         <section id="action-launched" data-include="fragments/actions/caliper-action-launched.html"></section>
+        <section id="action-liked" data-include="fragments/actions/caliper-action-liked.html"></section>
+        <section id="action-linked" data-include="fragments/actions/caliper-action-linked.html"></section>
         <section id="action-modified" data-include="fragments/actions/caliper-action-modified.html"></section>
         <section id="action-navigatedTo" data-include="fragments/actions/caliper-action-navigatedto.html"></section>
         <section id="action-optedIn" data-include="fragments/actions/caliper-action-optedin.html"></section>

--- a/fragments/actions/caliper-action-enteredfullscreen.html
+++ b/fragments/actions/caliper-action-enteredfullscreen.html
@@ -1,0 +1,17 @@
+<h3>EnteredFullScreen</h3>
+<p>The <em>EnteredFullScreen</em> action signals that a view mode that utilizes all the available display surface of a
+    screen has been engaged. Inverse of <a href="#action-exitedFullScreen">ExitedFullScreen</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/EnteredFullScreen</dd>
+    <dt>Term</dt>
+    <dd>EnteredFullScreen</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/202020375-v">To come or go into</a> a view mode that utilizes all
+        the available display surface of a screen. Inverse of <a href="#action-exitedFullScreen">ExitedFullScreen</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-exitedfullscreen.html
+++ b/fragments/actions/caliper-action-exitedfullscreen.html
@@ -1,0 +1,18 @@
+<h3>ExitedFullScreen</h3>
+<p>The <em>ExitedFullScreen</em> action signals that a view mode that utilizes all the available display surface of a
+    screen has been exited or closed. Inverse of <a href="#action-enteredFullScreen">EnteredFullScreen</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/ExitedFullScreen</dd>
+    <dt>Term</dt>
+    <dd>ExitedFullScreen</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/202019450-v">Move out of or depart from</a> a view mode that
+        utilizes all the available display surface of a screen. Inverse of
+        <a href="#action-enteredFullScreen">EnteredFullScreen</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-forwardedto.html
+++ b/fragments/actions/caliper-action-forwardedto.html
@@ -1,0 +1,15 @@
+<h3>ForwardedTo</h3>
+<p>The <em>ForwardedTo</em> action signals that an <a href="#Entity">Entity</a> has been sent, directed to, or shared
+    elsewhere. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/ForwardedTo</dd>
+    <dt>Term</dt>
+    <dd>ForwardedTo</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201959367-v">Send or ship onward</a>.</dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-graded.html
+++ b/fragments/actions/caliper-action-graded.html
@@ -1,0 +1,17 @@
+<h3>Graded</h3>
+<p>The <em>Graded</em> action signals that a grade or rank has been assigned to some work or <a href=#Entity>Entity</a>.
+    ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Graded</dd>
+    <dt>Term</dt>
+    <dd>Graded</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200659399-v">Assign a grade or rank to, according to one's
+        evaluation</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#GradeEvent">GradeEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-hid.html
+++ b/fragments/actions/caliper-action-hid.html
@@ -1,0 +1,17 @@
+<h3>Hid</h3>
+<p>The <em>Hid</em> action signals that an <a href=#Entity>Entity</a> has been hidden or collapsed to prevent discovery.
+    Inverse of <a href="#action-showed">Showed</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Hid</dd>
+    <dt>Term</dt>
+    <dd>Hid</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/202149298-v">Prevent from being seen or discovered</a>. Inverse
+        of <a href="#action-showed">Showed</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-highlighted.html
+++ b/fragments/actions/caliper-action-highlighted.html
@@ -1,0 +1,17 @@
+<h3>Highlighted</h3>
+<p>The <em>Highlighted</em> action signals that some content has been marked so as to make it more prominent or visible.
+    ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Highlighted</dd>
+    <dt>Term</dt>
+    <dd>Highlighted</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200515150-v">Move into the foreground to make more visible or
+        prominent</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#AnnotationEvent">AnnotationEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-identified.html
+++ b/fragments/actions/caliper-action-identified.html
@@ -1,0 +1,17 @@
+<h3>Identified</h3>
+<p>The <em>Identified</em> action signals that the identity of an <a href=#Entity>Entity</a> has been determined or
+    established. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Identified</dd>
+    <dt>Term</dt>
+    <dd>Identified</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200620568-v">Recognize as being; establish the identity of
+        someone or something</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-jumpedto.html
+++ b/fragments/actions/caliper-action-jumpedto.html
@@ -1,0 +1,17 @@
+<h3>JumpedTo</h3>
+<p>The <em>JumpedTo</em> action signals that the active state, place, or focus was changed abruptly to another.
+    ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/JumpedTo</dd>
+    <dt>Term</dt>
+    <dd>JumpedTo</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200561468-v">Pass abruptly from one state or topic to
+        another</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-liked.html
+++ b/fragments/actions/caliper-action-liked.html
@@ -1,0 +1,17 @@
+<h3>Liked</h3>
+<p>The <em>Liked</em> action signals that a <a href="#Person">Person</a> indicated their liking or approval of an
+    <a href="#Entity">Entity</a>. Inverse of <a href="#action-disliked">Disliked</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Liked</dd>
+    <dt>Term</dt>
+    <dd>Liked</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201780873-v">Be fond of</a>. Inverse of
+        <a href="#action-disliked">Disliked</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-linked.html
+++ b/fragments/actions/caliper-action-linked.html
@@ -1,0 +1,15 @@
+<h3>Linked</h3>
+<p>The <em>Linked</em> action signals that two or more resources were connected by way of a URI. ...TO DO</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Linked</dd>
+    <dt>Term</dt>
+    <dd>Linked</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201357376-v">Connect, fasten, or put together two or more
+        pieces</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a></dd>
+</dl>


### PR DESCRIPTION
This PR includes the next ten action HTML docs under fragments/actions, as well as the sections with data-include attributes referencing them in caliper-spec-respec.html.