### PR TITLE
Remaining action docs and refs in respec; fixing link in commented doc

### DIFF
--- a/caliper-spec-respec.html
+++ b/caliper-spec-respec.html
@@ -1331,23 +1331,46 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superceded by new SearchEvent.
         <section id="action-launched" data-include="fragments/actions/caliper-action-launched.html"></section>
         <section id="action-liked" data-include="fragments/actions/caliper-action-liked.html"></section>
         <section id="action-linked" data-include="fragments/actions/caliper-action-linked.html"></section>
+        <section id="action-loggedIn" data-include="fragments/actions/caliper-action-loggedin.html"></section>
+        <section id="action-loggedOut" data-include="fragments/actions/caliper-action-loggedOut.html"></section>
+        <section id="action-markedAsRead" data-include="fragments/actions/caliper-action-markedasread.html"></section>
+        <section id="action-markedAsUnread" data-include="fragments/actions/caliper-action-markedasunread.html"></section>
         <section id="action-modified" data-include="fragments/actions/caliper-action-modified.html"></section>
+        <section id="action-muted" data-include="fragments/actions/caliper-action-muted.html"></section>
         <section id="action-navigatedTo" data-include="fragments/actions/caliper-action-navigatedto.html"></section>
+        <section id="action-openedPopout" data-include="fragments/actions/caliper-action-openedpopout.html"></section>
         <section id="action-optedIn" data-include="fragments/actions/caliper-action-optedin.html"></section>
         <section id="action-optedOut" data-include="fragments/actions/caliper-action-optedout.html"></section>
+        <section id="action-paused" data-include="fragments/actions/caliper-action-paused.html"></section>
+        <section id="action-posted" data-include="fragments/actions/caliper-action-posted.html"></section>
         <section id="action-printed" data-include="fragments/actions/caliper-action-printed.html"></section>
         <section id="action-published" data-include="fragments/actions/caliper-action-published.html"></section>
+        <section id="action-questioned" data-include="fragments/actions/caliper-action-questioned.html"></section>
         <section id="action-ranked" data-include="fragments/actions/caliper-action-ranked.html"></section>
+        <section id="action-recommended" data-include="fragments/actions/caliper-action-recommended.html"></section>
+        <section id="action-removed" data-include="fragments/actions/caliper-action-removed.html"></section>
+        <section id="action-reset" data-include="fragments/actions/caliper-action-reset.html"></section>
+        <section id="action-restarted" data-include="fragments/actions/caliper-action-restarted.html"></section>
         <section id="action-restored" data-include="fragments/actions/caliper-action-restored.html"></section>
+        <section id="action-resumed" data-include="fragments/actions/caliper-action-resumed.html"></section>
         <section id="action-retrieved" data-include="fragments/actions/caliper-action-retrieved.html"></section>
         <section id="action-returned" data-include="fragments/actions/caliper-action-returned.html"></section>
+        <section id="action-reviewed" data-include="fragments/actions/caliper-action-reviewed.html"></section>
+        <section id="action-rewound" data-include="fragments/actions/caliper-action-rewound.html"></section>
         <section id="action-saved" data-include="fragments/actions/caliper-action-saved.html"></section>
         <section id="action-searched" data-include="fragments/actions/caliper-action-searched.html"></section>
         <section id="action-sent" data-include="fragments/actions/caliper-action-sent.html"></section>
+        <section id="action-shared" data-include="fragments/actions/caliper-action-shared.html"></section>
+        <section id="action-showed" data-include="fragments/actions/caliper-action-showed.html"></section>
         <section id="action-skipped" data-include="fragments/actions/caliper-action-skipped.html"></section>
         <section id="action-started" data-include="fragments/actions/caliper-action-started.html"></section>
         <section id="action-submitted" data-include="fragments/actions/caliper-action-submitted.html"></section>
+        <section id="action-subscribed" data-include="fragments/actions/caliper-action-subscribed.html"></section>
+        <section id="action-tagged" data-include="fragments/actions/caliper-action-tagged.html"></section>
+        <section id="action-timedout" data-include="fragments/actions/caliper-action-timedout.html"></section>
+        <section id="action-unmuted" data-include="fragments/actions/caliper-action-unmuted.html"></section>
         <section id="action-unpublished" data-include="fragments/actions/caliper-action-unpublished.html"></section>
+        <section id="action-unsubscribed" data-include="fragments/actions/caliper-action-unsubscribed.html"></section>
         <section id="action-uploaded" data-include="fragments/actions/caliper-action-uploaded.html"></section>
         <section id="action-used" data-include="fragments/actions/caliper-action-used.html"></section>
         <section id="action-viewed" data-include="fragments/actions/caliper-action-viewed.html"></section>

--- a/fragments/actions/caliper-action-commented.html
+++ b/fragments/actions/caliper-action-commented.html
@@ -1,6 +1,6 @@
 <h3>Commented</h3>
 <p>The <em>Commented</em> action signals that qualitative feedback in the form of a
-    <a href="#entity-Comment">Comment</a> has been provided.
+    <a href="#Comment">Comment</a> has been provided.
 </p>
 
 <dl>

--- a/fragments/actions/caliper-action-loggedin.html
+++ b/fragments/actions/caliper-action-loggedin.html
@@ -1,0 +1,18 @@
+<h3>LoggedIn</h3>
+<p>The <em>LoggedIn</em> action signals that a <a href="Person">Person</a> has gained authenticated access to an
+    <a href=#Entity>Entity</a>, usually a <a href="#SoftwareApplication">SoftwareApplication</a>. Inverse of
+    <a href="#action-loggedOut">LoggedOut</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/LoggedIn</dd>
+    <dt>Term</dt>
+    <dd>LoggedIn</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/202253955-v">Enter a computer or software application</a>.
+        Inverse of <a href="#action-loggedOut">LoggedOut</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#SessionEvent">SessionEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-loggedout.html
+++ b/fragments/actions/caliper-action-loggedout.html
@@ -1,0 +1,18 @@
+<h3>LoggedOut</h3>
+<p>The <em>LoggedOut</em> action signals that a <a href="Person">Person</a> has ended an authenticated visit to
+    <a href=#Entity>Entity</a>, usually a <a href="#SoftwareApplication">SoftwareApplication</a>. Inverse of
+    <a href="#action-loggedIn">LoggedIn</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/LoggedOut</dd>
+    <dt>Term</dt>
+    <dd>LoggedOut</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/202254101-v">Exit a computer or software application</a>. Inverse
+        of <a href="#action-loggedIn">LoggedIn</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#SessionEvent">SessionEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-markedasread.html
+++ b/fragments/actions/caliper-action-markedasread.html
@@ -1,0 +1,20 @@
+<h3>MarkedAsRead</h3>
+<p>The <em>MarkedAsRead</em> action signals that textual content has been labeled as read or consumed. Inverse of
+    <a href="#action-markedAsUnread">MarkedAsUnread</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/MarkedAsRead</dd>
+    <dt>Term</dt>
+    <dd>MarkedAsRead</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200923709-v">Mark: designate as if by a mark</a>;
+        <a href="http://wordnet-rdf.princeton.edu/wn31/200626756-v">read: interpret something that is written or
+            printed</a>. Inverse of <a href="#action-markedAsUnread">MarkedAsUnread</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MessageEvent">MessageEvent</a>,
+        <a href="#ThreadEvent">ThreadEvent</a>
+    </dd>
+</dl>

--- a/fragments/actions/caliper-action-markedasunread.html
+++ b/fragments/actions/caliper-action-markedasunread.html
@@ -1,0 +1,18 @@
+<h3>MarkedAsUnread</h3>
+<p>The <em>MarkedAsUnread</em> action signals that textual content has been labeled as not yet read or consumed.
+    Inverse of <a href="#action-markedAsRead">MarkedAsRead</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/MarkedAsUnread</dd>
+    <dt>Term</dt>
+    <dd>MarkedAsUnread</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200923709-v">Mark: designate as if by a mark</a>. ...TO DO
+        Inverse of <a href="#action-markedAsRead">MarkedAsRead</a>.</dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MessageEvent">MessageEvent</a>,
+        <a href="#ThreadEvent">ThreadEvent</a>
+    </dd>
+</dl>

--- a/fragments/actions/caliper-action-muted.html
+++ b/fragments/actions/caliper-action-muted.html
@@ -1,0 +1,17 @@
+<h3>Muted</h3>
+<p>The <em>Muted</em> action signals that the sound associated with an <a href=#Entity>Entity</a> has been cut off or
+    silenced. Inverse of <a href="#action-unmuted">Unmuted</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Muted</dd>
+    <dt>Term</dt>
+    <dd>Muted</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/mute-v">Deaden (a sound or noise)</a>. Inverse of
+        <a href="#action-unmuted">Unmuted</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-openedpopout.html
+++ b/fragments/actions/caliper-action-openedpopout.html
@@ -1,0 +1,17 @@
+<h3>OpenedPopout</h3>
+<p>The <em>OpenedPopout</em> action signals that a video popout has been opened. Inverse of
+    <a href="#action-closedPopout">ClosedPopout</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/OpenedPopout</dd>
+    <dt>Term</dt>
+    <dd>OpenedPopout</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/202431018-v">Start to operate or function or cause to start
+        operating or functioning</a> a video popout. Inverse of <a href="#action-closedPopout">ClosedPopout</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-paused.html
+++ b/fragments/actions/caliper-action-paused.html
@@ -1,0 +1,19 @@
+<h3>Paused</h3>
+<p>The <em>Paused</em> action signals that some task or process has been temporarily stopped. Inverse of
+    <a href="#action-resumed">Resumed</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Paused</dd>
+    <dt>Term</dt>
+    <dd>Paused</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200781106-v">Cease an action temporarily</a>. Inverse of
+        <a href="#action-resumed">Resumed</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#AssessmentEvent">AssessmentEvent</a>,
+        <a href="#MediaEvent">MediaEvent</a>
+    </dd>
+</dl>

--- a/fragments/actions/caliper-action-posted.html
+++ b/fragments/actions/caliper-action-posted.html
@@ -1,0 +1,16 @@
+<h3>Posted</h3>
+<p>The <em>Posted</em> action signals that some <a href=#Entity>Entity</a> has been published in a shared space. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Posted</dd>
+    <dt>Term</dt>
+    <dd>Posted</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201033289-v">To cause to be directed or transmitted to another
+        place</a>. ...TO DO
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MessageEvent">MessageEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-questioned.html
+++ b/fragments/actions/caliper-action-questioned.html
@@ -1,0 +1,13 @@
+<h3>Questioned</h3>
+<p>The <em>Questioned</em> action signals that a question has been posed. ...TO DO</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Questioned</dd>
+    <dt>Term</dt>
+    <dd>Questioned</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200786670-v">Pose a question</a>.</dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-recommended.html
+++ b/fragments/actions/caliper-action-recommended.html
@@ -1,0 +1,14 @@
+<h3>Recommended</h3>
+<p>The <em>Recommended</em> action signals that some <a href=#Entity>Entity</a> or option is favored. ...TO DO</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Recommended</dd>
+    <dt>Term</dt>
+    <dd>Recommended</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200884469-v">Express a good opinion of</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-removed.html
+++ b/fragments/actions/caliper-action-removed.html
@@ -1,0 +1,17 @@
+<h3>Removed</h3>
+<p>The <em>Removed</em> action signals the taking away or deletion of some <a href=#Entity>Entity</a>. Inverse of
+    <a href="#action-added">Added</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Removed</dd>
+    <dt>Term</dt>
+    <dd>Removed</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200181704-v">Remove from sight</a>. Inverse of
+        <a href="#action-added">Added</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-reset.html
+++ b/fragments/actions/caliper-action-reset.html
@@ -1,0 +1,15 @@
+<h3>Reset</h3>
+<p>The <em>Reset</em> action signals that an <a href=#Entity>Entity</a> has been refreshed or returned to its original
+    state. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Reset</dd>
+    <dt>Term</dt>
+    <dd>Reset</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200949623-v">Set anew</a>.</dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#AssessmentEvent">AssessmentEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-restarted.html
+++ b/fragments/actions/caliper-action-restarted.html
@@ -1,0 +1,19 @@
+<h3>Restarted</h3>
+<p>The <em>Restarted</em> action signals that a process or task has begun again from the beginning, following a
+    previous run or attempt. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Restarted</dd>
+    <dt>Term</dt>
+    <dd>Restarted</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200350758-v">Take up or begin anew</a>, as in to start something,
+        make progress but then stop and return to the beginning in order to start again.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#AssessmentEvent">AssessmentEvent</a>,
+        <a href="#MediaEvent">MediaEvent</a>
+    </dd>
+</dl>

--- a/fragments/actions/caliper-action-resumed.html
+++ b/fragments/actions/caliper-action-resumed.html
@@ -1,0 +1,20 @@
+<h3>Resumed</h3>
+<p>The <em>Resumed</em> action signals that a process or task was started midway through after it was previously paused
+    at that place. Inverse of <a href="#action-paused">Paused</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Resumed</dd>
+    <dt>Term</dt>
+    <dd>Resumed</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200350758-v">Take up or begin anew</a>, as in to start something,
+        pause and then begin again at the location where the pause in action occurred. Inverse of
+        <a href="#action-paused">Paused</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#AssessmentEvent">AssessmentEvent</a>,
+        <a href="#MediaEvent">MediaEvent</a>
+    </dd>
+</dl>

--- a/fragments/actions/caliper-action-reviewed.html
+++ b/fragments/actions/caliper-action-reviewed.html
@@ -1,0 +1,15 @@
+<h3>Reviewed</h3>
+<p>The <em>Reviewed</em> action signals that an <a href=#Entity>Entity</a> has been looked over or appraised for its
+    quality and completeness. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Reviewed</dd>
+    <dt>Term</dt>
+    <dd>Reviewed</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200857194-v">Appraise critically</a>.</dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#AssignableEvent">AssignableEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-rewound.html
+++ b/fragments/actions/caliper-action-rewound.html
@@ -1,0 +1,15 @@
+<h3>Rewound</h3>
+<p>The <em>Rewound</em> action signals that a process was moved back from a current place or state to a previous one.
+    ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Rewound</dd>
+    <dt>Term</dt>
+    <dd>Rewound</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201524927-v">Wind up again</a>.</dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-shared.html
+++ b/fragments/actions/caliper-action-shared.html
@@ -1,0 +1,15 @@
+<h3>Shared</h3>
+<p>The <em>Shared</em> action signals that a reference to an <a href=#Entity>Entity</a> was communicated in order to
+    share with others an experience, information, or knowledge. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Shared</dd>
+    <dt>Term</dt>
+    <dd>Shared</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201065952-v">Communicate</a>.</dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#AnnotationEvent">AnnotationEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-showed.html
+++ b/fragments/actions/caliper-action-showed.html
@@ -1,0 +1,17 @@
+<h3>Showed</h3>
+<p>The <em>Showed</em> action signals that an <a href=#Entity>Entity</a> has been revealed or made visible to enable
+    discovery. Inverse of <a href="#action-hid">Hid</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Showed</dd>
+    <dt>Term</dt>
+    <dd>Showed</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/202141597-v">Make visible or noticeable</a>. Inverse of
+        <a href="#action-hid">Hid</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-subscribed.html
+++ b/fragments/actions/caliper-action-subscribed.html
@@ -1,0 +1,17 @@
+<h3>Subscribed</h3>
+<p>The <em>Subscribed</em> action signals that a request was made for the regular delivery of information. Inverse
+    of <a href="#action-unsubscribed">Unsubscribed</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Subscribed</dd>
+    <dt>Term</dt>
+    <dd>Subscribed</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/202214527-v">Receive or obtain regularly</a>. Inverse of
+        <a href="#action-unsubscribed">Unsubscribed</a>.
+    </dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#ForumEvent">ForumEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-tagged.html
+++ b/fragments/actions/caliper-action-tagged.html
@@ -1,0 +1,13 @@
+<h3>Tagged</h3>
+<p>The <em>Taged</em> action signals that some kind of content was given a tag or label. ...TO DO</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Tagged</dd>
+    <dt>Term</dt>
+    <dd>Tagged</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201591414-v">Attach a tag or label to</a>.</dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#AnnotationEvent">AnnotationEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-timedout.html
+++ b/fragments/actions/caliper-action-timedout.html
@@ -1,0 +1,15 @@
+<h3>TimedOut</h3>
+<p>The <em>TimedOut</em> action signals that a user session was cancelled after a predetermined time interval passed
+    without activity. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/TimedOut</dd>
+    <dt>Term</dt>
+    <dd>TimedOut</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd>Cancellation of a user session after a predetermined time interval has occurred without activity. ...TO DO</dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#SessionEvent">SessionEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-unmuted.html
+++ b/fragments/actions/caliper-action-unmuted.html
@@ -1,0 +1,15 @@
+<h3>Unmuted</h3>
+<p>The <em>Unmuted</em> action signals that the sound associated with an <a href=#Entity>Entity</a> has been enabled or
+    made audible. Inverse of <a href="#action-muted">Muted</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Unmuted</dd>
+    <dt>Term</dt>
+    <dd>Unmuted</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd>Inverse of <a href="#action-muted">Muted</a>. ...TO DO</dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>
+</dl>

--- a/fragments/actions/caliper-action-unsubscribed.html
+++ b/fragments/actions/caliper-action-unsubscribed.html
@@ -1,0 +1,15 @@
+<h3>Unsubscribed</h3>
+<p>The <em>Unsubscribed</em> action signals that a request was made for the regular delivery of information to be
+    stopped or ceased. Inverse of <a href="#action-subscribed">Subscribed</a>. ...TO DO
+</p>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>https://purl.imsglobal.org/caliper/actions/Unsubscribed</dd>
+    <dt>Term</dt>
+    <dd>Unsubscribed</dd>
+    <dt>WordNet&reg; Gloss</dt>
+    <dd>Inverse of <a href="#action-subscribed">Subscribed</a>. ...TO DO</dd>
+    <dt>Supported by</dt>
+    <dd><a href="#Event">Event</a>, <a href="#ForumEvent">ForumEvent</a></dd>
+</dl>


### PR DESCRIPTION
This PR includes 23 new action HTML docs under fragments/actions for the remaining action, as well as new sections with data-include attributes in the respec doc referring to them. A small fix was also made to a link in caliper-action-commented.html.