### PR TITLE
Editing 21 actions to use new Related Gloss(es) format

### DIFF
--- a/fragments/actions/caliper-action-abandoned.html
+++ b/fragments/actions/caliper-action-abandoned.html
@@ -7,8 +7,11 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Abandoned</dd>
     <dt>Term</dt>
     <dd>Abandoned</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/202232813-v">Forsake, leave behind</a>.</dd>
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/202232813-v">abandon (verb)</a> |
+        "forsake, leave behind"
+    </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-accepted.html
+++ b/fragments/actions/caliper-action-accepted.html
@@ -8,9 +8,10 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Accepted</dd>
     <dt>Term</dt>
     <dd>Accepted</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200799359-v">Give an affirmative reply to</a>.
-        Inverse of <a href="#action-declined">Declined</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/200799359-v">accept, go for, consent (verb)</a> |
+        "give an affirmative reply to; respond favorably to"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#SurveyInvitationEvent">SurveyInvitationEvent</a></dd>

--- a/fragments/actions/caliper-action-activated.html
+++ b/fragments/actions/caliper-action-activated.html
@@ -8,9 +8,10 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Activated</dd>
     <dt>Term</dt>
     <dd>Activated</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200191014-v">Make active or more active</a>. Inverse of
-        <a href="#action-deactivated">Deactivated</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/200191014-v">activate (verb)</a> |
+        "make active or more active"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#AssignableEvent"></a></dd>

--- a/fragments/actions/caliper-action-added.html
+++ b/fragments/actions/caliper-action-added.html
@@ -8,9 +8,10 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Added</dd>
     <dt>Term</dt>
     <dd>Added</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200182551-v">Make an addition (to); join or combine or unite with
-        others; increase the quality, quantity, size or scope of</a>. Inverse of <a href="#action-removed">Removed</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/200182551-v">add (verb)</a> |
+        "make an addition (to); join or combine or unite with others; increase the quality, quantity, size or scope of"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a></dd>

--- a/fragments/actions/caliper-action-archived.html
+++ b/fragments/actions/caliper-action-archived.html
@@ -6,9 +6,10 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Archived</dd>
     <dt>Term</dt>
     <dd>Archived</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201387292-v" rel="nofollow">Put into
-        an archive</a>. Inverse of <a href="#action-restored">Restored</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/201387292-v">archive, file away (verb)</a> |
+        "put into an archive"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>

--- a/fragments/actions/caliper-action-attached.html
+++ b/fragments/actions/caliper-action-attached.html
@@ -7,8 +7,11 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Attached</dd>
     <dt>Term</dt>
     <dd>Attached</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201299048-v">Cause to be attached</a>.</dd>
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/201299048-v">attach (verb)</a> |
+        "cause to be attached"
+    </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-bookmarked.html
+++ b/fragments/actions/caliper-action-bookmarked.html
@@ -8,9 +8,10 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Bookmarked</dd>
     <dt>Term</dt>
     <dd>Bookmarked</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/102874508-n">A marker</a> that specifies a location of interest
-        in a <a href="#DigitalResource">DigitalResource</a> that is recorded for later retrieval.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/102874508-n">bookmarker, bookmark (noun)</a> |
+        "a marker (a piece of paper or ribbon) placed between the pages of a book to mark the reader's place"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#AnnotationEvent">AnnotationEvent</a></dd>

--- a/fragments/actions/caliper-action-changedresolution.html
+++ b/fragments/actions/caliper-action-changedresolution.html
@@ -1,5 +1,5 @@
 <h3>ChangedResolution</h3>
-<p>The <em>ChangedResolution</em> action signals that the number of pixels per square inch on a comptuer-generated
+<p>The <em>ChangedResolution</em> action signals that the number of pixels per square inch on a computer-generated
    display has been changed or adjusted. ...TO DO
 </p>
 
@@ -8,10 +8,15 @@
     <dd>https://purl.imsglobal.org/caliper/actions/ChangedResolution</dd>
     <dt>Term</dt>
     <dd>ChangedResolution</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200126072-v">Cause to change; make different; cause a
-        transformation</a> of <a href="http://wordnet-rdf.princeton.edu/wn31/111526370-n">the number of pixels per
-        square inch on a computer-generated display</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/200126072-v">modify, alter, change (verb)</a> |
+        "cause to change; make different; cause a transformation"
+    </dd>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/111526370-n">resolution (noun)</a> |
+        "the number of pixels per square inch on a computer-generated display; the greater the resolution, the better
+        the picture"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>

--- a/fragments/actions/caliper-action-changedsize.html
+++ b/fragments/actions/caliper-action-changedsize.html
@@ -6,10 +6,14 @@
     <dd>https://purl.imsglobal.org/caliper/actions/ChangedSize</dd>
     <dt>Term</dt>
     <dd>ChangedSize</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200126072-v">Cause to change; make different; cause a
-        transformation</a> of <a href="http://wordnet-rdf.princeton.edu/wn31/105106204-n">the physical magnitude of
-        something</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/200126072-v">modify, alter, change (verb)</a> |
+        "cause to change; make different; cause a transformation"
+    </dd>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/105106204-n">size (noun)</a> |
+        "the physical magnitude of something (how big it is)"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>

--- a/fragments/actions/caliper-action-changedspeed.html
+++ b/fragments/actions/caliper-action-changedspeed.html
@@ -6,10 +6,14 @@
     <dd>https://purl.imsglobal.org/caliper/actions/ChangedSpeed</dd>
     <dt>Term</dt>
     <dd>ChangedSpeed</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200126072-v">Cause to change; make different; cause a
-        transformation</a> of the <a href="http://wordnet-rdf.princeton.edu/wn31/105065291-n">rate at which
-        something happens</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/200126072-v">modify, alter, change (verb)</a> |
+        "cause to change; make different; cause a transformation"
+    </dd>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/105065291-n">speed, fastness, swiftness (noun)</a> |
+        "a rate (usually rapidly) at which something happens"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>

--- a/fragments/actions/caliper-action-changedvolume.html
+++ b/fragments/actions/caliper-action-changedvolume.html
@@ -8,10 +8,14 @@
     <dd>https://purl.imsglobal.org/caliper/actions/ChangedVolume</dd>
     <dt>Term</dt>
     <dd>ChangedVolume</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200126072-v">Cause to change; make different; cause a
-        transformation</a> of <a href="http://wordnet-rdf.princeton.edu/wn31/104997456-n">the magnitude of sound
-        (usually in a specified direction)</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/200126072-v">modify, alter, change (verb)</a> |
+        "cause to change; make different; cause a transformation"
+    </dd>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/104997456-n">intensity, volume, loudness (noun)</a> |
+        "the magnitude of sound (usually in a specified direction)"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>

--- a/fragments/actions/caliper-action-classified.html
+++ b/fragments/actions/caliper-action-classified.html
@@ -8,8 +8,11 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Classified</dd>
     <dt>Term</dt>
     <dd>Classified</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200741667-v">Assign to a class or kind</a>.</dd>
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/200741667-v">classify, relegate (verb)</a> |
+        "assign to a class or kind"
+    </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-closedpopout.html
+++ b/fragments/actions/caliper-action-closedpopout.html
@@ -8,9 +8,10 @@
     <dd>https://purl.imsglobal.org/caliper/actions/ClosedPopout</dd>
     <dt>Term</dt>
     <dd>ClosedPopout</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201349660-v">Close or shut</a> a video popout. Inverse of
-        <a href="#action-openedPopout">OpenedPopout</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/201349660-v">close, shut (verb)</a> |
+        "become closed"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#MediaEvent">MediaEvent</a></dd>

--- a/fragments/actions/caliper-action-commented.html
+++ b/fragments/actions/caliper-action-commented.html
@@ -8,9 +8,10 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Commented</dd>
     <dt>Term</dt>
     <dd>Commented</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201060446-v">Make or
-        write a comment on</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/201060446-v">comment, point out, remark, notice (verb)</a> |
+        "make or write a comment on"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#FeedbackEvent">FeedbackEvent</a></dd>

--- a/fragments/actions/caliper-action-completed.html
+++ b/fragments/actions/caliper-action-completed.html
@@ -7,8 +7,11 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Completed</dd>
     <dt>Term</dt>
     <dd>Completed</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200485097-v">Come or bring to a finish or an end</a>.</dd>
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/200485097-v">finish, complete (verb)</a> |
+        "come or bring to a finish or an end"
+    </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#AssessmentItemEvent">AssessmentItemEvent</a>,
         <a href="#QuestionnaireItemEvent">QuestionnaireItemEvent</a></dd>

--- a/fragments/actions/caliper-action-copied.html
+++ b/fragments/actions/caliper-action-copied.html
@@ -6,8 +6,11 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Copied</dd>
     <dt>Term</dt>
     <dd>Copied</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201697776-v">Make a replica of</a>.</dd>
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/201697776-v">re-create, copy (verb)</a> |
+        "make a replica of"
+    </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>
 </dl>

--- a/fragments/actions/caliper-action-created.html
+++ b/fragments/actions/caliper-action-created.html
@@ -8,9 +8,10 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Created</dd>
     <dt>Term</dt>
     <dd>Created</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201620211-v" rel="nofollow">Make or
-        cause to be or to become</a>. Inverse of <a href="#action-deleted">Deleted</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/201620211-v">make, create (verb)</a> |
+        "make or cause to be or to become"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>

--- a/fragments/actions/caliper-action-deactivated.html
+++ b/fragments/actions/caliper-action-deactivated.html
@@ -8,10 +8,12 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Deactivated</dd>
     <dt>Term</dt>
     <dd>Deactivated</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200191849-v">Make inactive</a>. Inverse of
-        <a href="#action-activated">Activated</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/200191849-v">inactivate, deactivate (verb)</a> |
+        "make inactive"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#AssignableEvent">AssignableEvent</a></dd>
+</dl>
 </dl>

--- a/fragments/actions/caliper-action-declined.html
+++ b/fragments/actions/caliper-action-declined.html
@@ -8,9 +8,10 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Declined</dd>
     <dt>Term</dt>
     <dd>Declined</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/202242120-v">Refuse to accept</a>.
-        Inverse of <a href="#action-accepted">Accepted</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/202242120-v">decline, turn down, reject, pass up, refuse (verb)
+        </a> | "refuse to accept"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#SurveyInvitationEvent">SurveyInvitationEvent</a>

--- a/fragments/actions/caliper-action-deleted.html
+++ b/fragments/actions/caliper-action-deleted.html
@@ -8,9 +8,10 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Deleted</dd>
     <dt>Term</dt>
     <dd>Deleted</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/201001860-v">Wipe out digitally</a>. Inverse of
-        <a href="#action-created">Created</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/201001860-v">delete, erase (verb)</a> |
+        "wipe out digitally or magnetically recorded information"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>

--- a/fragments/actions/caliper-action-described.html
+++ b/fragments/actions/caliper-action-described.html
@@ -6,9 +6,10 @@
     <dd>https://purl.imsglobal.org/caliper/actions/Described</dd>
     <dt>Term</dt>
     <dd>Described</dd>
-    <dt>WordNet&reg; Gloss</dt>
-    <dd><a href="http://wordnet-rdf.princeton.edu/wn31/200989103-v">Give a
-        description of</a>.
+    <dt>Related Gloss(es)</dt>
+    <dd><a href="http://wordnet-rdf.princeton.edu/">http://wordnet-rdf.princeton.edu/</a> |
+        <a href="http://wordnet-rdf.princeton.edu/wn31/200989103-v">depict, draw, describe (verb)</a> |
+        "give a description of"
     </dd>
     <dt>Supported by</dt>
     <dd><a href="#Event">Event</a>, <a href="#ResourceManagementEvent">ResourceManagementEvent</a></dd>


### PR DESCRIPTION
This PR includes edited versions of the first 21 action HTML docs under fragments/actions, using the new Related Gloss(es) dt tag and formatting as discussed. I have two questions related to my work on these edits.

1) As I have been reworking these docs, I have been checking the WordNet links and adding details about the terms and their definitions from those pages (see caliper-action-changedresolution.html and caliper-action-declined.html for examples). Is this okay, or would you prefer something slimmer, like only using the terms that share a root with the action name? I was adding this information to be transparent, but I could see it being too much.

2) For caliper-action-changedspeed.html, I thought that the speed gloss from WordNet was a little off (http://wordnet-rdf.princeton.edu/wn31/105065291-n) since speed here doesn't imply fast or slow, and that perhaps this one (http://wordnet-rdf.princeton.edu/id/15307914-n) was more on point. Would you agree? Also, I had trouble finding a reliable URI for the new sense using the /wn31/ pattern; I think if you add a random number in front of the ID it does work (try http://wordnet-rdf.princeton.edu/wn31/015307914-n). The WordNet site seems a bit finicky.