### PR TITLE
Adding LIS roles and statuses

### DIFF
--- a/caliper-spec-respec.html
+++ b/caliper-spec-respec.html
@@ -3252,6 +3252,53 @@ TODO: DEFINE NEW EXAMPLE. v1p1 example superceded by new SearchEvent.
             <section id="metric-unitspassed" data-include="fragments/usemetrics/caliper-metric-unitspassed.html"></section>
             <section id="metric-wordsread" data-include="fragments/usemetrics/caliper-metric-wordsread.html"></section>
         </section>
+
+        <section id="lis-roles">
+            <h3>LIS Roles</h3>
+            <p><a href="#membership">Membership</a> includes an optional <code>roles</code> property for assigning one
+                or more roles to an <a href="#Event">Event</a> <code>actor</code> described as a <code>member</code> of
+                an <code>organization</code>. Role values are limited to the list of Caliper role terms derived from the
+                IMS <a href="#lisDef">LIS</a> specification. Assigning context roles should prove sufficient in most
+                cases. Whenever a sub-role is specified, the related context role SHOULD also be included. For example,
+                a role of <code>Instructor#TeachingAssistant</code> SHOULD always be accompanied by the
+                <code>Instructor</code> role.
+            </p>
+            <section id="role-administrator" data-include="fragments/roles/lis-role-administrator.html"></section>
+            <section id="role-contentdeveloper" data-include="fragments/roles/lis-role-contentdeveloper.html"></section>
+            <section id="role-instructor" data-include="fragments/roles/lis-role-instructor.html"></section>
+            <section id="role-learner" data-include="fragments/roles/lis-role-learner.html"></section>
+            <section id="role-manager" data-include="fragments/roles/lis-role-manager.html"></section>
+            <section id="role-member" data-include="fragments/roles/lis-role-member.html"></section>
+            <section id="role-mentor" data-include="fragments/roles/lis-role-mentor.html"></section>
+            <section id="role-officer" data-include="fragments/roles/lis-role-officer.html"></section>
+        </section>
+
+        <section id="lis-statuses">
+            <h3>LIS Statuses</h3>
+            <p>The status associated with a <a href="#Membership">Membership</a> within an organization can be set to
+                one of the following states: Active or Inactive. These states are derived from the IMS
+                <a href="#lisDef">LIS</a> specification. The value MUST be set to the appropriate
+                <a href="#termDef">Term</a> string value. ...TO DO
+            </p>
+            <section id="lis-status-active">
+                <h4>Active</h4>
+                <dl>
+                    <dt>IRI</dt>
+                    <dd>http://purl.imsglobal.org/vocab/lis/v2/status#Active</dd>
+                    <dt>Term</dt>
+                    <dd>Active</dd>
+                </dl>
+            </section>
+            <section id="lis-status-inactive">
+                <h4>Inactive</h4>
+                <dl>
+                    <dt>IRI</dt>
+                    <dd>http://purl.imsglobal.org/vocab/lis/v2/status#Inactive</dd>
+                    <dt>Term</dt>
+                    <dd>Inactive</dd>
+                </dl>
+            </section>
+        </section>
     </section>
 
     <section id="jsonld">

--- a/fragments/entities/caliper-entity-membership.html
+++ b/fragments/entities/caliper-entity-membership.html
@@ -57,7 +57,7 @@
         <td>roles</td>
         <td>Array</td>
         <td>An ordered collection of organizational roles assigned to the <code>member</code>. Role values are limited
-            to the list of Caliper defined <a href="#Roles">role</a> terms. Whenever a subrole is specified, the core
+            to the list of Caliper defined <a href="#lis-roles">role</a> terms. Whenever a subrole is specified, the core
             context role SHOULD also be included; for example, a role of <em>Instructor#TeachingAssistant</em>
             should always be accompanied by the <em>Instructor</em> role.
         </td>
@@ -67,7 +67,7 @@
         <td>status</td>
         <td><a href="#term">Term</a></td>
         <td>A string value that indicates the current standing of the <code>member</code>. If a status is specified, the
-            value be chosen from the list of Caliper defined <a href="#status">statuses</a>.
+            value be chosen from the list of Caliper defined <a href="#lis-statuses">statuses</a>.
         </td>
         <td>Optional</td>
     </tr>

--- a/fragments/roles/lis-role-administrator.html
+++ b/fragments/roles/lis-role-administrator.html
@@ -1,0 +1,87 @@
+<h4>Administrator</h4>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>http://purl.imsglobal.org/vocab/lis/v2/membership#Administrator</dd>
+    <dt>Term</dt>
+    <dd>Administrator</dd>
+    <dt>Subrole(s)</dt>
+    <dd>
+        <section id="subrole-administrator-administrator" class="notoc">
+            <h5>Administrator#Administrator</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Administrator</dd>
+                <dt>Term</dt>
+                <dd>Administrator#Administrator</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-administrator-developer" class="notoc">
+            <h5>Administrator#Developer</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Developer</dd>
+                <dt>Term</dt>
+                <dd>Administrator#Developer</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-administrator-externaldeveloper" class="notoc">
+            <h5>Administrator#ExternalDeveloper</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#ExternalDeveloper</dd>
+                <dt>Term</dt>
+                <dd>Administrator#ExternalDeveloper</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-administrator-externalsupport" class="notoc">
+            <h5>Administrator#ExternalSupport</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#ExternalSupport</dd>
+                <dt>Term</dt>
+                <dd>Administrator#ExternalSupport</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-administrator-externalsystemadministrator" class="notoc">
+            <h5>Administrator#ExternalSystemAdministrator</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#ExternalSystemAdministrator</dd>
+                <dt>Term</dt>
+                <dd>Administrator#ExternalSystemAdministrator</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-administrator-support" class="notoc">
+            <h5>Administrator#Support</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#Support</dd>
+                <dt>Term</dt>
+                <dd>Administrator#Support</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-administrator-systemadministrator" class="notoc">
+            <h5>Administrator#SystemAdministrator</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Administrator#SystemAdministrator</dd>
+                <dt>Term</dt>
+                <dd>Administrator#SystemAdministrator</dd>
+            </dl>
+        </section>
+    </dd>
+</dl>
+

--- a/fragments/roles/lis-role-contentdeveloper.html
+++ b/fragments/roles/lis-role-contentdeveloper.html
@@ -1,0 +1,53 @@
+<h4>ContentDeveloper</h4>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>http://purl.imsglobal.org/vocab/lis/v2/membership#ContentDeveloper</dd>
+    <dt>Term</dt>
+    <dd>ContentDeveloper</dd>
+    <dt>Subrole(s)</dt>
+    <dd>
+        <section id="subrole-contentdeveloper-contentdeveloper" class="notoc">
+            <h5>ContentDeveloper#ContentDeveloper</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ContentDeveloper</dd>
+                <dt>Term</dt>
+                <dd>ContentDeveloper#ContentDeveloper</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-contentdeveloper-contentexpert" class="notoc">
+            <h5>ContentDeveloper#ContentExpert</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ContentExpert</dd>
+                <dt>Term</dt>
+                <dd>ContentDeveloper#ContentExpert</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-contentdeveloper-externalcontentexpert" class="notoc">
+            <h5>ContentDeveloper#ExternalContentExpert</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#ExternalContentExpert</dd>
+                <dt>Term</dt>
+                <dd>ContentDeveloper#ExternalContentExpert</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-contentdeveloper-librarian" class="notoc">
+            <h5>ContentDeveloper#Librarian</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/ContentDeveloper#Librarian</dd>
+                <dt>Term</dt>
+                <dd>ContentDeveloper#Librarian</dd>
+            </dl>
+        </section>
+    </dd>
+</dl>

--- a/fragments/roles/lis-role-instructor.html
+++ b/fragments/roles/lis-role-instructor.html
@@ -1,0 +1,140 @@
+<h4>Instructor</h4>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor</dd>
+    <dt>Term</dt>
+    <dd>Instructor</dd>
+    <dd>
+        <section id="subrole-instructor-externalinstructor" class="notoc">
+            <h5>Instructor#ExternalInstructor</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#ExternalInstructor</dd>
+                <dt>Term</dt>
+                <dd>Instructor#ExternalInstructor</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-instructor-grader" class="notoc">
+            <h5>Instructor#Grader</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#Grader</dd>
+                <dt>Term</dt>
+                <dd>Instructor#Grader</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-instructor-guestinstructor" class="notoc">
+            <h5>Instructor#GuestInstructor</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#GuestInstructor</dd>
+                <dt>Term</dt>
+                <dd>Instructor#GuestInstructor</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-instructor-instructor" class="notoc">
+            <h5>Instructor#Instructor</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#Instructor</dd>
+                <dt>Term</dt>
+                <dd>Instructor#Instructor</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-instructor-lecturer" class="notoc">
+            <h5>Instructor#Lecturer</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#Lecturer</dd>
+                <dt>Term</dt>
+                <dd>Instructor#Lecturer</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-instructor-primaryinstructor" class="notoc">
+            <h5>Instructor#PrimaryInstructor</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#PrimaryInstructor</dd>
+                <dt>Term</dt>
+                <dd>Instructor#PrimaryInstructor</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-instructor-secondaryinstructor" class="notoc">
+            <h5>Instructor#SecondaryInstructor</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#SecondaryInstructor</dd>
+                <dt>Term</dt>
+                <dd>Instructor#SecondaryInstructor</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-instructor-teachingassistant" class="notoc">
+            <h5>Instructor#TeachingAssistant</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistant</dd>
+                <dt>Term</dt>
+                <dd>Instructor#TeachingAssistant</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-instructor-teachingassistantgroup" class="notoc">
+            <h5>Instructor#TeachingAssistantGroup</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistantGroup</dd>
+                <dt>Term</dt>
+                <dd>Instructor#TeachingAssistantGroup</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-instructor-teachingassistantoffering" class="notoc">
+            <h5>Instructor#TeachingAssistantOffering</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistantOffering</dd>
+                <dt>Term</dt>
+                <dd>Instructor#TeachingAssistantOffering</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-instructor-teachingassistantsection" class="notoc">
+            <h5>Instructor#TeachingAssistantSection</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistantSection</dd>
+                <dt>Term</dt>
+                <dd>Instructor#TeachingAssistantSection</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-instructor-teachingassistanttemplate" class="notoc">
+            <h5>Instructor#TeachingAssistantTemplate</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistantTemplate</dd>
+                <dt>Term</dt>
+                <dd>Instructor#TeachingAssistantTemplate</dd>
+            </dl>
+        </section>
+    </dd>
+</dl>

--- a/fragments/roles/lis-role-learner.html
+++ b/fragments/roles/lis-role-learner.html
@@ -1,0 +1,58 @@
+<h4>Learner</h4>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>http://purl.imsglobal.org/vocab/lis/v2/membership#Learner</dd>
+    <dt>Term</dt>
+    <dd>Learner</dd>
+    <dt>Subrole(s)</dt>
+    <dd>
+        <section id="subrole-learner-externallearner" class="notoc">
+            <h5>Learner#ExternalLearner</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#ExternalLearner</dd>
+                <dt>Term</dt>
+                <dd>Learner#ExternalLearner</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-learner-guestlearner" class="notoc">
+            <h5>Learner#GuestLearner</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#GuestLearner</dd>
+                <dt>Term</dt>
+                <dd>Learner#GuestLearner</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-learner-learner" class="notoc">
+            <h5>Learner#Learner</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#Learner</dd>
+                <dt>Term</dt>
+                <dd>Learner#Learner</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-learner-noncreditlearner" class="notoc">
+            <h5>Learner#NonCreditLearner</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Learner#NonCreditLearner</dd>
+                <dt>Term</dt>
+                <dd>Learner#NonCreditLearner</dd>
+            </dl>
+        </section>
+    </dd>
+</dl>
+
+
+
+
+

--- a/fragments/roles/lis-role-manager.html
+++ b/fragments/roles/lis-role-manager.html
@@ -1,0 +1,64 @@
+<h4>Manager</h4>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>http://purl.imsglobal.org/vocab/lis/v2/membership#Manager</dd>
+    <dt>Term</dt>
+    <dd>Manager</dd>
+    <dt>Subrole(s)</dt>
+    <dd>
+        <section id="subrole-manager-areamanager" class="notoc">
+            <h5>Manager#AreaManager</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Manager#AreaManager</dd>
+                <dt>Term</dt>
+                <dd>Manager#AreaManager</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-manager-coursecoordinator" class="notoc">
+            <h5>Manager#CourseCoordinator</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Manager#CourseCoordinator</dd>
+                <dt>Term</dt>
+                <dd>Manager#CourseCoordinator</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-manager-externalobserver" class="notoc">
+            <h5>Manager#ExternalObserver</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Manager#ExternalObserver</dd>
+                <dt>Term</dt>
+                <dd>Manager#ExternalObserver</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-manager-manager" class="notoc">
+            <h5>Manager#Manager</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Manager#Manager</dd>
+                <dt>Term</dt>
+                <dd>Manager#Manager</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-manager-observer" class="notoc">
+            <h5>Manager#Observer</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Manager#Observer</dd>
+                <dt>Term</dt>
+                <dd>Manager#Observer</dd>
+            </dl>
+        </section>
+    </dd>
+</dl>

--- a/fragments/roles/lis-role-member.html
+++ b/fragments/roles/lis-role-member.html
@@ -1,0 +1,21 @@
+<h4>Member</h4>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>http://purl.imsglobal.org/vocab/lis/v2/membership#Member</dd>
+    <dt>Term</dt>
+    <dd>Member</dd>
+    <dt>Subrole(s)</dt>
+    <dd>
+        <section id="subrole-member-member" class="notoc">
+            <h5>Member#Member</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Member#Member</dd>
+                <dt>Term</dt>
+                <dd>Member#Member</dd>
+            </dl>
+        </section>
+    </dd>
+</dl>
+

--- a/fragments/roles/lis-role-mentor.html
+++ b/fragments/roles/lis-role-mentor.html
@@ -1,0 +1,130 @@
+<h4>Mentor</h4>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>http://purl.imsglobal.org/vocab/lis/v2/membership#Mentor</dd>
+    <dt>Term</dt>
+    <dd>Mentor</dd>
+    <dt>Subrole(s)</dt>
+    <dd>
+        <section id="subrole-mentor-advisor" class="notoc">
+            <h5>Mentor#Advisor</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Mentor#Advisor</dd>
+                <dt>Term</dt>
+                <dd>Mentor#Advisor</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-mentor-externaladvisor" class="notoc">
+            <h5>Mentor#ExternalAdvisor</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Mentor#ExternalAdvisor</dd>
+                <dt>Term</dt>
+                <dd>Mentor#ExternalAdvisor</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-mentor-externalauditor" class="notoc">
+            <h5>Mentor#ExternalAuditor</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Mentor#ExternalAuditor</dd>
+                <dt>Term</dt>
+                <dd>Mentor#ExternalAuditor</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-mentor-externallearningfacilitator" class="notoc">
+            <h5>Mentor#ExternalLearningFacilitator</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Mentor#ExternalLearningFacilitator</dd>
+                <dt>Term</dt>
+                <dd>Mentor#ExternalLearningFacilitator</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-mentor-externalmentor" class="notoc">
+            <h5>Mentor#ExternalMentor</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Mentor#ExternalMentor</dd>
+                <dt>Term</dt>
+                <dd>Mentor#ExternalMentor</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-mentor-externalreviewer" class="notoc">
+            <h5>Mentor#ExternalReviewer</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Mentor#ExternalReviewer</dd>
+                <dt>Term</dt>
+                <dd>Mentor#ExternalReviewer</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-mentor-externaltutor" class="notoc">
+            <h5>Mentor#ExternalTutor</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Mentor#ExternalTutor</dd>
+                <dt>Term</dt>
+                <dd>Mentor#ExternalTutor</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-mentor-learningfacilitator" class="notoc">
+            <h5>Mentor#LearningFacilitator</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Mentor#LearningFacilitator</dd>
+                <dt>Term</dt>
+                <dd>Mentor#LearningFacilitator</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-mentor-mentor" class="notoc">
+            <h5>Mentor#Mentor</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Mentor#Mentor</dd>
+                <dt>Term</dt>
+                <dd>Mentor#Mentor</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-mentor-reviewer" class="notoc">
+            <h5>Mentor#Reviewer</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Mentor#Reviewer</dd>
+                <dt>Term</dt>
+                <dd>Mentor#Reviewer</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-mentor-tutor" class="notoc">
+            <h5>Mentor#Tutor</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Mentor#Tutor</dd>
+                <dt>Term</dt>
+                <dd>Mentor#Tutor</dd>
+            </dl>
+        </section>
+    </dd>
+</dl>

--- a/fragments/roles/lis-role-officer.html
+++ b/fragments/roles/lis-role-officer.html
@@ -1,0 +1,53 @@
+<h4>Officer</h4>
+
+<dl>
+    <dt>IRI</dt>
+    <dd>http://purl.imsglobal.org/vocab/lis/v2/membership#Officer</dd>
+    <dt>Term</dt>
+    <dd>Officer</dd>
+    <dt>Subrole(s)</dt>
+    <dd>
+        <section id="subrole-officer-chair" class="notoc">
+            <h5>Officer#Chair</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Officer#Chair</dd>
+                <dt>Term</dt>
+                <dd>Officer#Chair</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-officer-secretary" class="notoc">
+            <h5>Officer#Secretary</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Officer#Secretary</dd>
+                <dt>Term</dt>
+                <dd>Officer#Secretary</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-officer-treasurer">
+            <h5>Officer#Treasurer</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Officer#Treasurer</dd>
+                <dt>Term</dt>
+                <dd>Officer#Treasurer</dd>
+            </dl>
+        </section>
+    </dd>
+    <dd>
+        <section id="subrole-officer-vicechair" class="notoc">
+            <h5>Officer#Vice-Chair</h5>
+            <dl>
+                <dt>IRI</dt>
+                <dd>http://purl.imsglobal.org/vocab/lis/v2/membership/Officer#Vice-Chair</dd>
+                <dt>Term</dt>
+                <dd>Officer#Vice-Chair</dd>
+            </dl>
+        </section>
+    </dd>
+</dl>


### PR DESCRIPTION
This PR adds new content related to Roles (and Subroles) and Statuses from the LIS specification. A new subdirectory roles has been added under fragments, containing eight HTML role docs. Subroles are nested within each role's dl as dd tags following a "Subrole(s)" dt tag. Underneath a new LIS Roles section, sections with data-include attributes referencing the HTML role docs were added to caliper-spec-respec.html. In addition, a new section and two subsections were added to the base respec doc describing the two statuses from LIS. Finally, edits were made to the Membership subentity doc (caliper-entity-membership.html) under fragments/entities to correct the links to the LIS Roles and LIS Statuses sections.

I want to make two notes regarding my solution to representing the Roles (and subroles):

1) The header (h5) for each subrole nested under each role is currently displayed in italics. I believe this is controlled by respec, since the same effect does not occur when previewing the role HTML doc alone. We may want to explore whether we want the header to show up as normal or if this is fine. 

2) The sections enclosing the subroles have class attributes with "notoc" values, indicating that they should not be part of the respec TOC. I decided to do this since an additional nested level was making the TOC busy and hard to read. I'm happy to change this or explore alternatives.