### PR TITLE
Adding rough draft of General Profile to caliper-spec-respec

### DIFF
--- a/caliper-spec-respec.html
+++ b/caliper-spec-respec.html
@@ -711,10 +711,13 @@
              class="notoc">
         </section>
 
-        <section id="profile-general">
-            <h3>General Profile</h3>
+        <section id="profile-general" data-include="fragments/profiles/caliper-profile-general.html"></section>
 
+        <section id="profile-general-event-action"
+             data-include="fragments/profiles/caliper-profile-general-event-action.html"
+             class="notoc">
         </section>
+
     </section>
 
     <section id="serialization">

--- a/fragments/profiles/caliper-profile-general-event-action.html
+++ b/fragments/profiles/caliper-profile-general-event-action.html
@@ -1,0 +1,36 @@
+<h4><a href="#Event">Event</a> (any Caliper <a href="#actions">action</a>)</h4>
+
+<table class="data">
+    <thead>
+    <tr>
+        <th>Required</th>
+        <th colspan="2">Optional</th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+        <td>
+            <code>id</code>: "urn:uuid:&lt<a href="#uuidDef">UUID</a>&gt"<br />
+            <code>type</code>: "Event"<br />
+            <code>actor</code>: <a href="#Agent">Agent</a><br />
+            <code>action</code>: any Caliper <a href="#actions">action</a><br />
+            <code>object</code>: <a href="#Entity">Entity</a><br />
+            <code>eventTime</code>: DateTime
+        </td>
+        <td>
+            <code>profile</code>: "GeneralProfile"<br />
+            <code>generated</code>: <a href="#Entity">Entity</a><br />
+            <code>target</code>: <a href="#Entity">Entity</a><br />
+            <code>referrer</code>: <a href="#Entity">Entity</a><br />
+        </td>
+        <td>
+            <code>edApp</code>: <a href="#SoftwareApplication">SoftwareApplication</a><br />
+            <code>group</code>: <a href="#Organization">Organization</a><br />
+            <code>membership</code>: <a href="#Membership">Membership</a><br />
+            <code>session</code>: <a href="#Session">Session</a><br />
+            <code>federatedSession</code>: <a href="#LtiSession">LtiSession</a><br />
+            <code>extensions</code>: Object
+        </td>
+    </tr>
+    </tbody>
+</table>

--- a/fragments/profiles/caliper-profile-general.html
+++ b/fragments/profiles/caliper-profile-general.html
@@ -1,0 +1,17 @@
+<h3>General Profile</h3>
+
+<img height="100%" width="100%" src="assets/caliper-profile_general.png" alt="General Profile">
+
+<dl>
+    <dt>IRI</dt>
+    <dd><a href="http://purl.imsglobal.org/caliper/GeneralProfile">http://purl.imsglobal.org/caliper/GeneralProfile</a></dd>
+    <dt>Term</dt>
+    <dd>GeneralProfile</dd>
+</dl>
+
+<p>The Caliper General Profile provides a generic <a href="#Event">Event</a> for describing learning or supporting
+    activities that have yet to be modeled by Caliper. Any of the Caliper <a href="#actions">actions</a> described in this specification can
+    be used to describe the interaction between the <code>actor</code> and the <code>object.</code></p>
+
+<p>Use of the General Profile is strictly limited to describing interactions not modeled in other profiles. Any events
+    described MUST be expressed using only the <code>Event</code> supertype.</p>


### PR DESCRIPTION
This pull request adds General Profile content to `caliper-spec-respec.html`, specifically through two fragments (`caliper-profile-general.html` and `caliper-profile-general-event-action.html`) and associated data-includes in the base document.